### PR TITLE
add codecov action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,10 @@ jobs:
         cache: true
 
     - name: Run unit tests
-      run: make test-unit
+      run: go test -v ./... -coverprofile=coverage.out
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.out


### PR DESCRIPTION
This pull request updates the CI workflow to improve test coverage reporting. The main change is switching the unit test command to generate a coverage report and then uploading that report to Codecov for better visibility into test coverage.

**CI workflow improvements:**

* Changed the unit test command in `.github/workflows/ci.yml` to use `go test -v ./... -coverprofile=coverage.out`, which generates a coverage report.
* Added a step to upload the generated coverage report to Codecov using the `codecov/codecov-action@v5` GitHub Action.