### PR TITLE
Update versioning to use SemVer and commit hash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,16 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "github-actions"
-    directory: ".github/workflows"
+    directory: "/"
     schedule:
       interval: "monthly"
     groups:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
   lint:
     permissions:
       contents: read
-    uses: jsandas/github-actions/.github/workflows/golang-lint.yml@main
+    uses: jsandas/github-actions/.github/workflows/golang-lint.yml@13150b57906d67e1731f602c2b78a5d13b13b1bc
 
   security:
     permissions:
       contents: read
       security-events: write
-    uses: jsandas/github-actions/.github/workflows/golang-security.yml@main
+    uses: jsandas/github-actions/.github/workflows/golang-security.yml@13150b57906d67e1731f602c2b78a5d13b13b1bc
 
   test:
     name: Unit Tests
@@ -28,18 +28,19 @@ jobs:
     needs: [lint]
     
     steps:
-    - uses: actions/checkout@v6
-      
-    - uses: actions/setup-go@v6
-      with:
-        go-version-file: "go.mod"
-        cache: true
+      - uses: actions/checkout@v6.0.2
+        
+      - uses: actions/setup-go@v6.4.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
 
-    - name: Run unit tests
-      run: go test -v ./... -coverprofile=coverage.out
+      - name: Run unit tests
+        run: go test -v ./... -coverprofile=coverage.out
 
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./coverage.out
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.out
+          fail_ci_if_error: false

--- a/starttls/starttls.go
+++ b/starttls/starttls.go
@@ -3,6 +3,7 @@ package starttls
 import (
 	"bufio"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -317,17 +318,11 @@ func (p *mysqlProtocol) createSSLRequestPacket() []byte {
 	packet[3] = 1  // sequence number
 
 	// Client flags (4 bytes)
-	packet[4] = byte(clientFlags)
-	packet[5] = byte(clientFlags >> 8)
-	packet[6] = byte(clientFlags >> 16)
-	packet[7] = byte(clientFlags >> 24)
+	binary.LittleEndian.PutUint32(packet[4:8], clientFlags)
 
 	// Max packet size (4 bytes)
 	maxSize := uint32(maxMySQLPacketSize)
-	packet[8] = byte(maxSize)
-	packet[9] = byte(maxSize >> 8)
-	packet[10] = byte(maxSize >> 16)
-	packet[11] = byte(maxSize >> 24)
+	binary.LittleEndian.PutUint32(packet[8:12], maxSize)
 
 	// Character set
 	packet[12] = utf8GeneralCI


### PR DESCRIPTION
This pull request updates the project's GitHub workflow and dependency management configuration to improve reliability and reduce update noise. The most important changes are grouped below:

**Dependency update schedule and grouping:**

* Changed Dependabot update interval for both Go modules and GitHub Actions from weekly to monthly to reduce update frequency.
* Added grouping for all updates in Dependabot, so related updates are bundled together.

**Workflow reliability and version pinning:**

* Updated reusable workflow references in `ci.yml` to use a specific commit SHA instead of the `main` branch, ensuring consistent and repeatable workflow runs.
* Pinned action versions in the test job (`actions/checkout`, `actions/setup-go`, and `codecov/codecov-action`) to specific versions for more reliable builds. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL31-R33) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL42-R46)

**Codecov configuration:**

* Added `fail_ci_if_error: false` to the Codecov upload step to prevent CI failures if coverage upload encounters an error.