### PR TITLE
(feat) Add additional direct TLS ports 8443 and 9443

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Go module that handles STARTTLS negotiation for various protocols. STARTTLS al
 - POP3 (port 110)
 - FTP (port 21)
 - MySQL (port 3306)
-- Direct TLS ports (443, 465, 993, 995, 3389)
+- Direct TLS ports (443, 465, 993, 995, 3389, 8443, 9443)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ For more examples, see the [examples](./examples) directory.
 
 ### Direct TLS
 - Automatically handles ports that use direct TLS
-- No negotiation needed for ports 443, 465, 993, 995, 3389
+- No negotiation needed for ports 443, 465, 993, 995, 3389, 8443, 9443
 
 ## Error Handling
 

--- a/starttls/starttls.go
+++ b/starttls/starttls.go
@@ -410,7 +410,7 @@ func StartTLS(ctx context.Context, conn net.Conn, port string) error {
 	if !ok {
 		// These ports use direct TLS connections
 		switch port {
-		case "443", "465", "993", "995", "3389":
+		case "443", "465", "993", "995", "3389", "8443", "9443":
 			return nil
 		default:
 			return fmt.Errorf("%w: port %s", ErrUnsupportedProtocol, port)

--- a/starttls/starttls_test.go
+++ b/starttls/starttls_test.go
@@ -327,7 +327,7 @@ func TestStartTLS(t *testing.T) {
 }
 
 func TestDirectTLSPorts(t *testing.T) {
-	directTLSPorts := []string{"443", "465", "993", "995", "3389"}
+	directTLSPorts := []string{"443", "465", "993", "995", "3389", "8443", "9443"}
 
 	for _, port := range directTLSPorts {
 		t.Run(fmt.Sprintf("port_%s", port), func(t *testing.T) {


### PR DESCRIPTION
This pull request expands support for direct TLS ports in the STARTTLS module by adding ports 8443 and 9443. The changes update the documentation, implementation, and tests to recognize these ports as direct TLS ports.

**Direct TLS port support:**

* Updated the list of direct TLS ports in the `README.md` to include `8443` and `9443`.
* Modified the `StartTLS` function in `starttls.go` to treat ports `8443` and `9443` as direct TLS ports, returning early without attempting STARTTLS negotiation.
* Updated the `TestDirectTLSPorts` test in `starttls_test.go` to include `8443` and `9443` in the set of ports tested for direct TLS behavior.