### PR TITLE
Noop for all ports not in the protocols map

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,8 @@ For more examples, see the [examples](./examples) directory.
 - Checks SSL capability flags
 - Manages SSL request packet
 
-### HTTPS
-- No-op for all other ports
-
+### Non-STARTTLS (unknown) ports
+- No-op for ports that are not in the STARTTLS protocol map (callers should establish TLS directly when required)
 ## Error Handling
 
 The module provides specific error types:

--- a/README.md
+++ b/README.md
@@ -101,16 +101,14 @@ For more examples, see the [examples](./examples) directory.
 - Checks SSL capability flags
 - Manages SSL request packet
 
-### Direct TLS
-- Automatically handles ports that use direct TLS
-- No negotiation needed for ports 443, 465, 993, 995, 3389, 8443, 9443
+### HTTPS
+- No-op for all other ports
 
 ## Error Handling
 
 The module provides specific error types:
 - `ErrStartTLSNotSupported`: Server doesn't support STARTTLS
 - `ErrInvalidResponse`: Invalid server response
-- `ErrUnsupportedProtocol`: Protocol/port not supported
 
 ## Security Considerations
 

--- a/starttls/starttls.go
+++ b/starttls/starttls.go
@@ -16,7 +16,6 @@ import (
 var (
 	ErrStartTLSNotSupported = errors.New("STARTTLS not supported by server")
 	ErrInvalidResponse      = errors.New("invalid server response")
-	ErrUnsupportedProtocol  = errors.New("unsupported protocol")
 )
 
 // StartTLSProtocol defines the interface for protocol-specific STARTTLS implementations.
@@ -408,13 +407,8 @@ func StartTLS(ctx context.Context, conn net.Conn, port string) error {
 	// Check if this is a STARTTLS protocol
 	protocolFactory, ok := protocols[port]
 	if !ok {
-		// These ports use direct TLS connections
-		switch port {
-		case "443", "465", "993", "995", "3389", "8443", "9443":
-			return nil
-		default:
-			return fmt.Errorf("%w: port %s", ErrUnsupportedProtocol, port)
-		}
+		// If the port is not recognized, we assume STARTTLS not required and return nil.
+		return nil
 	}
 
 	protocol := protocolFactory()

--- a/starttls/starttls_test.go
+++ b/starttls/starttls_test.go
@@ -191,14 +191,6 @@ func TestStartTLS(t *testing.T) {
 			timeout: 2 * time.Second,
 		},
 		{
-			name:           "unsupported protocol",
-			port:           "1234",
-			serverMessages: []string{},
-			expectError:    true,
-			expectedError:  ErrUnsupportedProtocol,
-			timeout:        1 * time.Second,
-		},
-		{
 			name: "smtp starttls not supported",
 			port: "25",
 			serverMessages: []string{


### PR DESCRIPTION
This pull request simplifies how the `StartTLS` module handles unrecognized ports by removing the concept of "unsupported protocol" errors. Now, if the port is not recognized as a STARTTLS protocol, the function simply returns `nil` (no error), treating it as a no-op. This change also updates related documentation and tests.

**Error handling simplification:**

* Removed `ErrUnsupportedProtocol` error constant from `starttls.go` and all related error handling, so unrecognized ports no longer result in an error but are treated as a no-op. [[1]](diffhunk://#diff-e7e57b9eb6bc006eabe5e3d18896fa7f929b53bb981fbf9af161180aed0b0d22L19) [[2]](diffhunk://#diff-e7e57b9eb6bc006eabe5e3d18896fa7f929b53bb981fbf9af161180aed0b0d22L411-L417)
* Updated the test suite by removing the test case that expected an "unsupported protocol" error for unknown ports.

**Documentation update:**

* Updated the `README.md` to clarify that for ports not explicitly handled, the module is a no-op, and removed references to unsupported protocol errors.