### PR TITLE
(feat) Implement LDAP StartTLS and update integration tests and README

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,45 +24,11 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
-      - name: Prepare integration test assets
+      - name: Run integration tests
         run: |
           set -e
           bash setup.sh
-
-      - name: Start OpenLDAP
-        run: docker compose -f docker-compose.yml up --quiet-pull -d openldap
-
-      - name: Run LDAP integration test
-        run: |
-          set -euo pipefail
-
-          for attempt in 1 2 3 4 5; do
-            if go test -v -tags=integration -run TestLDAPStartTLS ./...; then
-              exit 0
-            fi
-
-            echo "LDAP test attempt ${attempt} failed"
-            docker compose -f docker-compose.yml logs --tail=200 openldap || true
-
-            if [ "$attempt" -lt 5 ]; then
-              sleep 10
-            fi
-          done
-
-          exit 1
-
-      - name: Stop OpenLDAP
-        if: always()
-        run: docker compose -f docker-compose.yml down --remove-orphans
-
-      - name: Start Postfix
-        run: docker compose -f docker-compose.yml up --quiet-pull -d postfix
-
-      - name: Run SMTP integration test
-        run: |
-          set -euo pipefail
-          go test -v -tags=integration -run TestSMTPStartTLS ./...
-
-      - name: Stop Postfix
-        if: always()
-        run: docker compose -f docker-compose.yml down --remove-orphans
+          trap 'docker compose -f docker-compose.yml down' EXIT
+          docker compose -f docker-compose.yml up --quiet-pull  -d
+          sleep 15
+          go test -v -tags=integration ./...

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,5 +28,5 @@ jobs:
           bash setup.sh
           trap 'docker compose -f docker-compose.yml down' EXIT
           docker compose -f docker-compose.yml up -d
-          sleep 15
+          sleep 30
           go test -v -tags=integration ./...

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,7 @@ jobs:
           cd integration_tests
           bash setup.sh
           trap 'docker compose logs openldap && docker compose -f docker-compose.yml down' EXIT
-          docker compose -f docker-compose.yml up -d
+          docker compose -f docker-compose.yml up --quiet-pull  -d
           sleep 30
-          timeout 5 telnet localhost 389
+          timeout 5 openssl s_client -connect localhost:389 -starttls ldap
           go test -v -tags=integration ./...

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,8 +26,9 @@ jobs:
           set -e
           cd integration_tests
           bash setup.sh
-          trap 'docker compose logs openldap && docker compose -f docker-compose.yml down' EXIT
+          ls -la
+          ls -la openldap/certs
+          trap 'docker compose -f docker-compose.yml down' EXIT
           docker compose -f docker-compose.yml up --quiet-pull  -d
-          sleep 30
-          timeout 5 openssl s_client -connect localhost:389 -starttls ldap
+          sleep 15
           go test -v -tags=integration ./...

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,8 +26,7 @@ jobs:
           set -e
           cd integration_tests
           bash setup.sh
-          trap 'docker compose -f docker-compose.yml down' EXIT
+          trap 'docker compose logs openldap && docker compose -f docker-compose.yml down' EXIT
           docker compose -f docker-compose.yml up -d
           sleep 30
           go test -v -tags=integration ./...
-          docker compose logs -f openldap

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run integration tests
         run: |
           set -e
-          bash setup.sh
+          bash setup.sh > /dev/null
           trap 'docker compose -f docker-compose.yml down' EXIT
           docker compose -f docker-compose.yml up --quiet-pull  -d
           sleep 15

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,4 +29,5 @@ jobs:
           trap 'docker compose logs openldap && docker compose -f docker-compose.yml down' EXIT
           docker compose -f docker-compose.yml up -d
           sleep 30
+          timeout 5 telnet localhost 389
           go test -v -tags=integration ./...

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,9 @@ jobs:
   test:
     name: Integration Tests
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: integration_tests
     
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -21,14 +24,45 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
-      - name: Run integration tests
+      - name: Prepare integration test assets
         run: |
           set -e
-          cd integration_tests
           bash setup.sh
-          ls -la
-          ls -la openldap/certs
-          trap 'docker compose -f docker-compose.yml down' EXIT
-          docker compose -f docker-compose.yml up --quiet-pull  -d
-          sleep 15
-          go test -v -tags=integration ./...
+
+      - name: Start OpenLDAP
+        run: docker compose -f docker-compose.yml up --quiet-pull -d openldap
+
+      - name: Run LDAP integration test
+        run: |
+          set -euo pipefail
+
+          for attempt in 1 2 3 4 5; do
+            if go test -v -tags=integration -run TestLDAPStartTLS ./...; then
+              exit 0
+            fi
+
+            echo "LDAP test attempt ${attempt} failed"
+            docker compose -f docker-compose.yml logs --tail=200 openldap || true
+
+            if [ "$attempt" -lt 5 ]; then
+              sleep 10
+            fi
+          done
+
+          exit 1
+
+      - name: Stop OpenLDAP
+        if: always()
+        run: docker compose -f docker-compose.yml down --remove-orphans
+
+      - name: Start Postfix
+        run: docker compose -f docker-compose.yml up --quiet-pull -d postfix
+
+      - name: Run SMTP integration test
+        run: |
+          set -euo pipefail
+          go test -v -tags=integration -run TestSMTPStartTLS ./...
+
+      - name: Stop Postfix
+        if: always()
+        run: docker compose -f docker-compose.yml down --remove-orphans

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run integration tests
         run: |
           set -e
-          bash setup.sh > /dev/null
+          bash setup.sh > /dev/null 2>&1
           trap 'docker compose -f docker-compose.yml down' EXIT
           docker compose -f docker-compose.yml up --quiet-pull  -d
           sleep 15

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,3 +30,4 @@ jobs:
           docker compose -f docker-compose.yml up -d
           sleep 30
           go test -v -tags=integration ./...
+          docker compose logs -f openldap

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,14 @@ test-unit:
 
 # Run integration tests
 test-integration:
-	cd integrationtests && bash setup.sh
-	docker compose -f integrationtests/docker-compose.yml up -d
+	cd integration_tests && bash setup.sh
+	docker compose -f integration_tests/docker-compose.yml up -d
 	sleep 15
-	cd integrationtests && go test -v -tags=integration ./...
+	cd integration_tests && go test -v -tags=integration ./...
 
 # Shutdown docker after integration tests
 test-integration-down:
-	docker compose -f integrationtests/docker-compose.yml down
+	docker compose -f integration_tests/docker-compose.yml down
 
 # Run all code quality checks
 quality: fmt-check go-mod-tidy lint

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Go module that handles STARTTLS negotiation for various protocols. STARTTLS al
 - IMAP (port 143)
 - POP3 (port 110)
 - FTP (port 21)
+- LDAP (port 389)
 - MySQL (port 3306)
 - Direct TLS ports (443, 465, 993, 995, 3389, 8443, 9443)
 
@@ -100,6 +101,11 @@ For more examples, see the [examples](./examples) directory.
 - Handles initial handshake packet
 - Checks SSL capability flags
 - Manages SSL request packet
+
+### LDAP
+- Sends StartTLS extended operation request
+- Uses BER encoding/decoding for request and response
+- Validates response message ID and result code
 
 ### Non-STARTTLS (unknown) ports
 - No-op for ports that are not in the STARTTLS protocol map (callers should establish TLS directly when required)

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -37,17 +37,17 @@ services:
     volumes:
       - ./openldap/certs:/etc/openldap/certs:ro
 
-  # # https://github.com/thkukuk/containers-mailserver/blob/master/postfix/README.md
-  # postfix:
-  #   image: registry.opensuse.org/opensuse/postfix
-  #   ports:
-  #     - "25:25"
-  #     - "587:587"
-  #   environment:
-  #     - SERVER_HOSTNAME=smtp.example.com
-  #     - ENABLE_SUBMISSION=1
-  #     - SMTPD_USE_TLS=1
-  #     - SMTPD_TLS_CRT=/etc/postfix/ssl/certs/tls.crt
-  #     - SMTPD_TLS_KEY=/etc/postfix/ssl/certs/tls.key
-  #   volumes:
-  #     - ./postfix/certs:/etc/postfix/ssl/certs:ro
+  # https://github.com/thkukuk/containers-mailserver/blob/master/postfix/README.md
+  postfix:
+    image: registry.opensuse.org/opensuse/postfix
+    ports:
+      - "25:25"
+      - "587:587"
+    environment:
+      - SERVER_HOSTNAME=smtp.example.com
+      - ENABLE_SUBMISSION=1
+      - SMTPD_USE_TLS=1
+      - SMTPD_TLS_CRT=/etc/postfix/ssl/certs/tls.crt
+      - SMTPD_TLS_KEY=/etc/postfix/ssl/certs/tls.key
+    volumes:
+      - ./postfix/certs:/etc/postfix/ssl/certs:ro

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -37,17 +37,17 @@ services:
     volumes:
       - ./openldap/certs:/etc/openldap/certs:ro
 
-  # https://github.com/thkukuk/containers-mailserver/blob/master/postfix/README.md
-  postfix:
-    image: registry.opensuse.org/opensuse/postfix
-    ports:
-      - "25:25"
-      - "587:587"
-    environment:
-      - SERVER_HOSTNAME=smtp.example.com
-      - ENABLE_SUBMISSION=1
-      - SMTPD_USE_TLS=1
-      - SMTPD_TLS_CRT=/etc/postfix/ssl/certs/tls.crt
-      - SMTPD_TLS_KEY=/etc/postfix/ssl/certs/tls.key
-    volumes:
-      - ./postfix/certs:/etc/postfix/ssl/certs:ro
+  # # https://github.com/thkukuk/containers-mailserver/blob/master/postfix/README.md
+  # postfix:
+  #   image: registry.opensuse.org/opensuse/postfix
+  #   ports:
+  #     - "25:25"
+  #     - "587:587"
+  #   environment:
+  #     - SERVER_HOSTNAME=smtp.example.com
+  #     - ENABLE_SUBMISSION=1
+  #     - SMTPD_USE_TLS=1
+  #     - SMTPD_TLS_CRT=/etc/postfix/ssl/certs/tls.crt
+  #     - SMTPD_TLS_KEY=/etc/postfix/ssl/certs/tls.key
+  #   volumes:
+  #     - ./postfix/certs:/etc/postfix/ssl/certs:ro

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - LDAP_TLS_KEY=/etc/openldap/certs/tls.key
       - LDAP_TLS_CA_CRT=/etc/openldap/certs/tls.crt
     volumes:
-      - ./openldap/certs:/etc/openldap/certs:ro
+      - ./openldap/certs:/etc/openldap/certs
 
   # https://github.com/thkukuk/containers-mailserver/blob/master/postfix/README.md
   postfix:
@@ -50,4 +50,4 @@ services:
       - SMTPD_TLS_CRT=/etc/postfix/ssl/certs/tls.crt
       - SMTPD_TLS_KEY=/etc/postfix/ssl/certs/tls.key
     volumes:
-      - ./postfix/certs:/etc/postfix/ssl/certs:ro
+      - ./postfix/certs:/etc/postfix/ssl/certs

--- a/integration_tests/ldap_test.go
+++ b/integration_tests/ldap_test.go
@@ -4,6 +4,7 @@ package integrationtests
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"os"
 	"testing"
@@ -21,9 +22,6 @@ func TestLDAPStartTLS(t *testing.T) {
 	}
 	if port == "" {
 		port = "389"
-	}
-	if port == "389" {
-		t.Skip("LDAP STARTTLS is not supported by starttls.StartTLS yet (port 389 is not in the protocol registry)")
 	}
 
 	addr := host + ":" + port
@@ -47,18 +45,18 @@ func TestLDAPStartTLS(t *testing.T) {
 
 	// attempting a TLS connection after StartTLS handshake fails which indicates that the
 	// StartTLS handshake was unsuccessful and needs to be reviewed.
-	// // Configure TLS
-	// tlsConfig := &tls.Config{
-	// 	ServerName:         "ldap.example.com",
-	// 	MinVersion:         tls.VersionTLS12,
-	// 	InsecureSkipVerify: true, // Set to true for testing purposes; in production, set to false and provide proper certificates
-	// }
+	// Configure TLS
+	tlsConfig := &tls.Config{
+		ServerName:         "ldap.example.com",
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true, // Set to true for testing purposes; in production, set to false and provide proper certificates
+	}
 
-	// // Upgrade connection to TLS
-	// tlsConn := tls.Client(conn, tlsConfig)
-	// if err := tlsConn.Handshake(); err != nil {
-	// 	t.Fatalf("TLS handshake failed: %v", err)
-	// }
+	// Upgrade connection to TLS
+	tlsConn := tls.Client(conn, tlsConfig)
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("TLS handshake failed: %v", err)
+	}
 
 	t.Log("Successfully completed LDAP StartTLS handshake")
 }

--- a/starttls/starttls.go
+++ b/starttls/starttls.go
@@ -265,44 +265,62 @@ func parseLDAPResponse(rw *bufio.ReadWriter) (int, error) {
 		return 0, fmt.Errorf("%w: expected LDAPMessage SEQUENCE, got tag 0x%02x", ErrInvalidResponse, tag)
 	}
 
-	messageIDTag, messageIDValue, rest, err := parseBERElement(payload)
+	messageID, protocolOpValue, err := parseLDAPMessageIDAndProtocolOp(payload)
 	if err != nil {
 		return 0, err
 	}
 
+	err = validateLDAPResultCode(protocolOpValue)
+	if err != nil {
+		return messageID, err
+	}
+
+	return messageID, nil
+}
+
+func parseLDAPMessageIDAndProtocolOp(payload []byte) (int, []byte, error) {
+	messageIDTag, messageIDValue, rest, err := parseBERElement(payload)
+	if err != nil {
+		return 0, nil, err
+	}
+
 	if messageIDTag != 0x02 {
-		return 0, fmt.Errorf("%w: expected messageID INTEGER, got tag 0x%02x", ErrInvalidResponse, messageIDTag)
+		return 0, nil, fmt.Errorf("%w: expected messageID INTEGER, got tag 0x%02x", ErrInvalidResponse, messageIDTag)
 	}
 
 	messageID, err := decodeBERInteger(messageIDValue)
 	if err != nil {
-		return 0, fmt.Errorf("%w: invalid messageID: %w", ErrInvalidResponse, err)
+		return 0, nil, fmt.Errorf("%w: invalid messageID: %w", ErrInvalidResponse, err)
 	}
 
 	_, protocolOpValue, _, err := parseBERElement(rest)
 	if err != nil {
-		return messageID, err
+		return messageID, nil, err
 	}
 
+	return messageID, protocolOpValue, nil
+}
+
+func validateLDAPResultCode(protocolOpValue []byte) error {
 	resultCodeTag, resultCodeValue, _, err := parseBERElement(protocolOpValue)
 	if err != nil {
-		return messageID, err
+		return err
 	}
 
 	if resultCodeTag != 0x0a && resultCodeTag != 0x02 {
-		return messageID, fmt.Errorf("%w: expected resultCode ENUMERATED, got tag 0x%02x", ErrInvalidResponse, resultCodeTag)
+		return fmt.Errorf("%w: expected resultCode ENUMERATED, got tag 0x%02x", ErrInvalidResponse, resultCodeTag)
 	}
 
 	resultCode, err := decodeBERInteger(resultCodeValue)
 	if err != nil {
-		return messageID, fmt.Errorf("%w: invalid resultCode: %w", ErrInvalidResponse, err)
+		return fmt.Errorf("%w: invalid resultCode: %w", ErrInvalidResponse, err)
 	}
 
 	if resultCode != 0 {
-		return messageID, fmt.Errorf("ldap resultCode=%d", resultCode)
+		return fmt.Errorf("ldap resultCode=%d", resultCode)
 	}
 
-	return messageID, nil
+	return nil
 }
 
 func encodeBERTLV(tag byte, value []byte) []byte {

--- a/starttls/starttls.go
+++ b/starttls/starttls.go
@@ -316,6 +316,10 @@ func encodeBERTLV(tag byte, value []byte) []byte {
 }
 
 func encodeBERLength(length int) []byte {
+	if length < 0 {
+		panic("encodeBERLength: negative length")
+	}
+
 	if length < 0x80 {
 		return []byte{byte(length)}
 	}
@@ -329,8 +333,26 @@ func encodeBERLength(length int) []byte {
 	}
 
 	content := tmp[pos:]
+
 	result := make([]byte, 1+len(content))
-	result[0] = 0x80 | byte(len(content))
+
+	if len(content) > 0x7f {
+		panic("encodeBERLength: length-of-length too large")
+	}
+
+	switch len(content) {
+	case 1:
+		result[0] = 0x81
+	case 2:
+		result[0] = 0x82
+	case 3:
+		result[0] = 0x83
+	case 4:
+		result[0] = 0x84
+	default:
+		panic("encodeBERLength: invalid length-of-length")
+	}
+
 	copy(result[1:], content)
 
 	return result

--- a/starttls/starttls.go
+++ b/starttls/starttls.go
@@ -210,14 +210,15 @@ func newLDAPProtocol() *ldapProtocol {
 }
 
 func (p *ldapProtocol) Handshake(ctx context.Context, rw *bufio.ReadWriter) error {
-	if err := ctx.Err(); err != nil {
+	err := ctx.Err()
+	if err != nil {
 		return err
 	}
 
 	messageID := int(atomic.AddUint32(&ldapMessageIDCounter, 1))
 	request := encodeStartTLSRequest(messageID)
 
-	_, err := rw.Write(request)
+	_, err = rw.Write(request)
 	if err != nil {
 		return fmt.Errorf("ldap: failed to write StartTLS request: %w", err)
 	}
@@ -227,7 +228,8 @@ func (p *ldapProtocol) Handshake(ctx context.Context, rw *bufio.ReadWriter) erro
 		return fmt.Errorf("ldap: failed to flush StartTLS request: %w", err)
 	}
 
-	if err := ctx.Err(); err != nil {
+	err = ctx.Err()
+	if err != nil {
 		return err
 	}
 
@@ -319,6 +321,7 @@ func encodeBERLength(length int) []byte {
 	}
 
 	var tmp [4]byte
+
 	pos := len(tmp)
 	for l := length; l > 0; l >>= 8 {
 		pos--
@@ -339,7 +342,9 @@ func encodeBERIntegerValue(n int) []byte {
 	}
 
 	var tmp [8]byte
+
 	i := len(tmp)
+
 	v := n
 	for v > 0 {
 		i--
@@ -367,6 +372,7 @@ func readBERElement(r *bufio.Reader) (byte, []byte, error) {
 	}
 
 	value := make([]byte, length)
+
 	_, err = io.ReadFull(r, value)
 	if err != nil {
 		return 0, nil, fmt.Errorf("%w: failed to read BER value: %v", ErrInvalidResponse, err)
@@ -395,6 +401,7 @@ func readBERLength(r *bufio.Reader) (int, error) {
 	}
 
 	buf := make([]byte, numBytes)
+
 	_, err = io.ReadFull(r, buf)
 	if err != nil {
 		return 0, fmt.Errorf("%w: failed to read BER length bytes: %v", ErrInvalidResponse, err)
@@ -414,12 +421,14 @@ func parseBERElement(data []byte) (byte, []byte, []byte, error) {
 	}
 
 	tag := data[0]
+
 	length, lengthBytes, err := parseBERLength(data[1:])
 	if err != nil {
 		return 0, nil, nil, err
 	}
 
 	start := 1 + lengthBytes
+
 	end := start + length
 	if end > len(data) {
 		return 0, nil, nil, fmt.Errorf("%w: BER element length exceeds payload", ErrInvalidResponse)

--- a/starttls/starttls.go
+++ b/starttls/starttls.go
@@ -233,26 +233,30 @@ func (p *ldapProtocol) Handshake(ctx context.Context, rw *bufio.ReadWriter) erro
 		return err
 	}
 
-type ldapResp struct {
-	id  int
-	err error
-}
-respCh := make(chan ldapResp, 1)
-go func() {
-	id, err := parseLDAPResponse(rw)
-	respCh <- ldapResp{id: id, err: err}
-}()
-
-var receivedID int
-select {
-case <-ctx.Done():
-	return ctx.Err()
-case resp := <-respCh:
-	if resp.err != nil {
-		return fmt.Errorf("ldap: failed to parse StartTLS response: %w", resp.err)
+	type ldapResp struct {
+		id  int
+		err error
 	}
-	receivedID = resp.id
-}
+
+	respCh := make(chan ldapResp, 1)
+
+	go func() {
+		id, err := parseLDAPResponse(rw)
+		respCh <- ldapResp{id: id, err: err}
+	}()
+
+	var receivedID int
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case resp := <-respCh:
+		if resp.err != nil {
+			return fmt.Errorf("ldap: failed to parse StartTLS response: %w", resp.err)
+		}
+
+		receivedID = resp.id
+	}
 
 	if receivedID != messageID {
 		return fmt.Errorf("ldap: messageID mismatch: sent=%d received=%d", messageID, receivedID)
@@ -281,12 +285,12 @@ func parseLDAPResponse(rw *bufio.ReadWriter) (int, error) {
 		return 0, fmt.Errorf("%w: expected LDAPMessage SEQUENCE, got tag 0x%02x", ErrInvalidResponse, tag)
 	}
 
-	messageID, protocolOpValue, err := parseLDAPMessageIDAndProtocolOp(payload)
+	messageID, protocolOpTag, protocolOpValue, err := parseLDAPMessageIDAndProtocolOp(payload)
 	if err != nil {
 		return 0, err
 	}
 
-	err = validateLDAPResultCode(protocolOpValue)
+	err = validateLDAPResultCode(protocolOpTag, protocolOpValue)
 	if err != nil {
 		return messageID, err
 	}
@@ -294,30 +298,35 @@ func parseLDAPResponse(rw *bufio.ReadWriter) (int, error) {
 	return messageID, nil
 }
 
-func parseLDAPMessageIDAndProtocolOp(payload []byte) (int, []byte, error) {
+func parseLDAPMessageIDAndProtocolOp(payload []byte) (int, byte, []byte, error) {
 	messageIDTag, messageIDValue, rest, err := parseBERElement(payload)
 	if err != nil {
-		return 0, nil, err
+		return 0, 0, nil, err
 	}
 
 	if messageIDTag != 0x02 {
-		return 0, nil, fmt.Errorf("%w: expected messageID INTEGER, got tag 0x%02x", ErrInvalidResponse, messageIDTag)
+		return 0, 0, nil, fmt.Errorf("%w: expected messageID INTEGER, got tag 0x%02x", ErrInvalidResponse, messageIDTag)
 	}
 
 	messageID, err := decodeBERInteger(messageIDValue)
 	if err != nil {
-		return 0, nil, fmt.Errorf("%w: invalid messageID: %w", ErrInvalidResponse, err)
+		return 0, 0, nil, fmt.Errorf("%w: invalid messageID: %w", ErrInvalidResponse, err)
 	}
 
-	_, protocolOpValue, _, err := parseBERElement(rest)
+	protocolOpTag, protocolOpValue, _, err := parseBERElement(rest)
 	if err != nil {
-		return messageID, nil, err
+		return messageID, 0, nil, err
 	}
 
-	return messageID, protocolOpValue, nil
+	return messageID, protocolOpTag, protocolOpValue, nil
 }
 
-func validateLDAPResultCode(protocolOpValue []byte) error {
+func validateLDAPResultCode(protocolOpTag byte, protocolOpValue []byte) error {
+	// StartTLS response uses ExtendedResponse [APPLICATION 24] (0x78).
+	if protocolOpTag != 0x78 {
+		return fmt.Errorf("%w: expected ExtendedResponse tag 0x78, got tag 0x%02x", ErrInvalidResponse, protocolOpTag)
+	}
+
 	resultCodeTag, resultCodeValue, _, err := parseBERElement(protocolOpValue)
 	if err != nil {
 		return err

--- a/starttls/starttls.go
+++ b/starttls/starttls.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"regexp"
 	"strings"
+	"sync/atomic"
 )
 
 // Protocol specific errors.
@@ -190,6 +191,292 @@ func (p *ftpProtocol) Handshake(ctx context.Context, rw *bufio.ReadWriter) error
 }
 
 func (p *ftpProtocol) Name() string {
+	return p.name
+}
+
+// LDAP protocol implementation.
+type ldapProtocol struct {
+	name string
+}
+
+const ldapStartTLS_OID = "1.3.6.1.4.1.1466.20037"
+
+var ldapMessageIDCounter uint32
+
+func newLDAPProtocol() *ldapProtocol {
+	return &ldapProtocol{
+		name: "ldap",
+	}
+}
+
+func (p *ldapProtocol) Handshake(ctx context.Context, rw *bufio.ReadWriter) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	messageID := int(atomic.AddUint32(&ldapMessageIDCounter, 1))
+	request := encodeStartTLSRequest(messageID)
+
+	_, err := rw.Write(request)
+	if err != nil {
+		return fmt.Errorf("ldap: failed to write StartTLS request: %w", err)
+	}
+
+	err = rw.Flush()
+	if err != nil {
+		return fmt.Errorf("ldap: failed to flush StartTLS request: %w", err)
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	receivedID, err := parseLDAPResponse(rw)
+	if err != nil {
+		return fmt.Errorf("ldap: failed to parse StartTLS response: %w", err)
+	}
+
+	if receivedID != messageID {
+		return fmt.Errorf("ldap: messageID mismatch: sent=%d received=%d", messageID, receivedID)
+	}
+
+	return nil
+}
+
+func encodeStartTLSRequest(messageID int) []byte {
+	messageIDField := encodeBERTLV(0x02, encodeBERIntegerValue(messageID))
+	// LDAP StartTLS ExtendedRequest uses [APPLICATION 23] (0x77) and
+	// requestName is context-specific [0] (0x80) carrying the OID value bytes.
+	requestNameField := encodeBERTLV(0x80, []byte(ldapStartTLS_OID))
+	protocolOpField := encodeBERTLV(0x77, requestNameField)
+
+	return encodeBERTLV(0x30, append(messageIDField, protocolOpField...))
+}
+
+func parseLDAPResponse(rw *bufio.ReadWriter) (int, error) {
+	tag, payload, err := readBERElement(rw.Reader)
+	if err != nil {
+		return 0, err
+	}
+
+	if tag != 0x30 {
+		return 0, fmt.Errorf("%w: expected LDAPMessage SEQUENCE, got tag 0x%02x", ErrInvalidResponse, tag)
+	}
+
+	messageIDTag, messageIDValue, rest, err := parseBERElement(payload)
+	if err != nil {
+		return 0, err
+	}
+
+	if messageIDTag != 0x02 {
+		return 0, fmt.Errorf("%w: expected messageID INTEGER, got tag 0x%02x", ErrInvalidResponse, messageIDTag)
+	}
+
+	messageID, err := decodeBERInteger(messageIDValue)
+	if err != nil {
+		return 0, fmt.Errorf("%w: invalid messageID: %w", ErrInvalidResponse, err)
+	}
+
+	_, protocolOpValue, _, err := parseBERElement(rest)
+	if err != nil {
+		return messageID, err
+	}
+
+	resultCodeTag, resultCodeValue, _, err := parseBERElement(protocolOpValue)
+	if err != nil {
+		return messageID, err
+	}
+
+	if resultCodeTag != 0x0a && resultCodeTag != 0x02 {
+		return messageID, fmt.Errorf("%w: expected resultCode ENUMERATED, got tag 0x%02x", ErrInvalidResponse, resultCodeTag)
+	}
+
+	resultCode, err := decodeBERInteger(resultCodeValue)
+	if err != nil {
+		return messageID, fmt.Errorf("%w: invalid resultCode: %w", ErrInvalidResponse, err)
+	}
+
+	if resultCode != 0 {
+		return messageID, fmt.Errorf("ldap resultCode=%d", resultCode)
+	}
+
+	return messageID, nil
+}
+
+func encodeBERTLV(tag byte, value []byte) []byte {
+	length := encodeBERLength(len(value))
+	tlv := make([]byte, 1+len(length)+len(value))
+	tlv[0] = tag
+	copy(tlv[1:], length)
+	copy(tlv[1+len(length):], value)
+
+	return tlv
+}
+
+func encodeBERLength(length int) []byte {
+	if length < 0x80 {
+		return []byte{byte(length)}
+	}
+
+	var tmp [4]byte
+	pos := len(tmp)
+	for l := length; l > 0; l >>= 8 {
+		pos--
+		tmp[pos] = byte(l)
+	}
+
+	content := tmp[pos:]
+	result := make([]byte, 1+len(content))
+	result[0] = 0x80 | byte(len(content))
+	copy(result[1:], content)
+
+	return result
+}
+
+func encodeBERIntegerValue(n int) []byte {
+	if n == 0 {
+		return []byte{0x00}
+	}
+
+	var tmp [8]byte
+	i := len(tmp)
+	v := n
+	for v > 0 {
+		i--
+		tmp[i] = byte(v)
+		v >>= 8
+	}
+
+	value := append([]byte(nil), tmp[i:]...)
+	if value[0]&0x80 != 0 {
+		value = append([]byte{0x00}, value...)
+	}
+
+	return value
+}
+
+func readBERElement(r *bufio.Reader) (byte, []byte, error) {
+	tag, err := r.ReadByte()
+	if err != nil {
+		return 0, nil, fmt.Errorf("%w: failed to read BER tag: %v", ErrInvalidResponse, err)
+	}
+
+	length, err := readBERLength(r)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	value := make([]byte, length)
+	_, err = io.ReadFull(r, value)
+	if err != nil {
+		return 0, nil, fmt.Errorf("%w: failed to read BER value: %v", ErrInvalidResponse, err)
+	}
+
+	return tag, value, nil
+}
+
+func readBERLength(r *bufio.Reader) (int, error) {
+	first, err := r.ReadByte()
+	if err != nil {
+		return 0, fmt.Errorf("%w: failed to read BER length: %v", ErrInvalidResponse, err)
+	}
+
+	if first&0x80 == 0 {
+		return int(first), nil
+	}
+
+	numBytes := int(first & 0x7f)
+	if numBytes == 0 {
+		return 0, fmt.Errorf("%w: BER indefinite length is not supported", ErrInvalidResponse)
+	}
+
+	if numBytes > 4 {
+		return 0, fmt.Errorf("%w: BER length too large", ErrInvalidResponse)
+	}
+
+	buf := make([]byte, numBytes)
+	_, err = io.ReadFull(r, buf)
+	if err != nil {
+		return 0, fmt.Errorf("%w: failed to read BER length bytes: %v", ErrInvalidResponse, err)
+	}
+
+	length := 0
+	for _, b := range buf {
+		length = (length << 8) | int(b)
+	}
+
+	return length, nil
+}
+
+func parseBERElement(data []byte) (byte, []byte, []byte, error) {
+	if len(data) < 2 {
+		return 0, nil, nil, fmt.Errorf("%w: BER element too short", ErrInvalidResponse)
+	}
+
+	tag := data[0]
+	length, lengthBytes, err := parseBERLength(data[1:])
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	start := 1 + lengthBytes
+	end := start + length
+	if end > len(data) {
+		return 0, nil, nil, fmt.Errorf("%w: BER element length exceeds payload", ErrInvalidResponse)
+	}
+
+	return tag, data[start:end], data[end:], nil
+}
+
+func parseBERLength(data []byte) (int, int, error) {
+	if len(data) == 0 {
+		return 0, 0, fmt.Errorf("%w: missing BER length", ErrInvalidResponse)
+	}
+
+	first := data[0]
+	if first&0x80 == 0 {
+		return int(first), 1, nil
+	}
+
+	numBytes := int(first & 0x7f)
+	if numBytes == 0 {
+		return 0, 0, fmt.Errorf("%w: BER indefinite length is not supported", ErrInvalidResponse)
+	}
+
+	if numBytes > 4 {
+		return 0, 0, fmt.Errorf("%w: BER length too large", ErrInvalidResponse)
+	}
+
+	if len(data) < 1+numBytes {
+		return 0, 0, fmt.Errorf("%w: incomplete BER length", ErrInvalidResponse)
+	}
+
+	length := 0
+	for i := 0; i < numBytes; i++ {
+		length = (length << 8) | int(data[1+i])
+	}
+
+	return length, 1 + numBytes, nil
+}
+
+func decodeBERInteger(data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, fmt.Errorf("empty BER integer")
+	}
+
+	if len(data) > 4 {
+		return 0, fmt.Errorf("BER integer too large")
+	}
+
+	value := 0
+	for _, b := range data {
+		value = (value << 8) | int(b)
+	}
+
+	return value, nil
+}
+
+func (p *ldapProtocol) Name() string {
 	return p.name
 }
 
@@ -399,6 +686,7 @@ var protocols = map[string]func() StartTLSProtocol{
 	"587":  func() StartTLSProtocol { return newSMTPProtocol() },
 	"110":  func() StartTLSProtocol { return newPOP3Protocol() },
 	"143":  func() StartTLSProtocol { return newIMAPProtocol() },
+	"389":  func() StartTLSProtocol { return newLDAPProtocol() },
 	"3306": func() StartTLSProtocol { return newMySQLProtocol() },
 }
 

--- a/starttls/starttls.go
+++ b/starttls/starttls.go
@@ -233,10 +233,26 @@ func (p *ldapProtocol) Handshake(ctx context.Context, rw *bufio.ReadWriter) erro
 		return err
 	}
 
-	receivedID, err := parseLDAPResponse(rw)
-	if err != nil {
-		return fmt.Errorf("ldap: failed to parse StartTLS response: %w", err)
+type ldapResp struct {
+	id  int
+	err error
+}
+respCh := make(chan ldapResp, 1)
+go func() {
+	id, err := parseLDAPResponse(rw)
+	respCh <- ldapResp{id: id, err: err}
+}()
+
+var receivedID int
+select {
+case <-ctx.Done():
+	return ctx.Err()
+case resp := <-respCh:
+	if resp.err != nil {
+		return fmt.Errorf("ldap: failed to parse StartTLS response: %w", resp.err)
 	}
+	receivedID = resp.id
+}
 
 	if receivedID != messageID {
 		return fmt.Errorf("ldap: messageID mismatch: sent=%d received=%d", messageID, receivedID)

--- a/starttls/starttls.go
+++ b/starttls/starttls.go
@@ -203,9 +203,14 @@ const ldapStartTLS_OID = "1.3.6.1.4.1.1466.20037"
 
 var ldapMessageIDCounter uint32
 
+const (
+	ldapProtocolName  = "ldap"
+	mysqlProtocolName = "mysql"
+)
+
 func newLDAPProtocol() *ldapProtocol {
 	return &ldapProtocol{
-		name: "ldap",
+		name: ldapProtocolName,
 	}
 }
 
@@ -561,7 +566,7 @@ type mysqlProtocol struct {
 
 func newMySQLProtocol() *mysqlProtocol {
 	return &mysqlProtocol{
-		name: "mysql",
+		name: mysqlProtocolName,
 	}
 }
 

--- a/starttls/starttls_test.go
+++ b/starttls/starttls_test.go
@@ -430,7 +430,12 @@ func TestLDAPHandshakeMessageIDMismatch(t *testing.T) {
 		defer close(serverErr)
 
 		reader := bufio.NewReader(serverConn)
-		_, payload, err := readBERElement(reader)
+
+		var payload []byte
+
+		var err error
+
+		_, payload, err = readBERElement(reader)
 		if err != nil {
 			serverErr <- err
 			return
@@ -444,8 +449,14 @@ func TestLDAPHandshakeMessageIDMismatch(t *testing.T) {
 
 		// Reply with a different message ID to trigger the mismatch branch.
 		response := buildLDAPExtendedResponse(messageID+1, 0)
+
 		_, err = serverConn.Write(response)
-		serverErr <- err
+		if err != nil {
+			serverErr <- err
+			return
+		}
+
+		serverErr <- nil
 	}()
 
 	err := StartTLS(ctx, clientConn, "389")
@@ -457,7 +468,8 @@ func TestLDAPHandshakeMessageIDMismatch(t *testing.T) {
 		t.Fatalf("expected messageID mismatch error, got: %v", err)
 	}
 
-	if err := <-serverErr; err != nil {
+	err = <-serverErr
+	if err != nil {
 		t.Fatalf("server error: %v", err)
 	}
 }
@@ -535,6 +547,7 @@ func TestReadBERLengthErrorCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := bufio.NewReader(bytes.NewReader(tt.data))
+
 			_, err := readBERLength(r)
 			if err == nil {
 				t.Fatal("expected error, got nil")
@@ -634,6 +647,7 @@ func TestLDAPHandshakeMalformedResponse(t *testing.T) {
 		defer close(serverErr)
 
 		reader := bufio.NewReader(serverConn)
+
 		_, _, err := readBERElement(reader)
 		if err != nil {
 			serverErr <- err
@@ -642,7 +656,12 @@ func TestLDAPHandshakeMalformedResponse(t *testing.T) {
 
 		// Invalid LDAP message tag to trigger parse failure path in Handshake.
 		_, err = serverConn.Write(encodeBERTLV(0x31, []byte{}))
-		serverErr <- err
+		if err != nil {
+			serverErr <- err
+			return
+		}
+
+		serverErr <- nil
 	}()
 
 	err := StartTLS(ctx, clientConn, "389")
@@ -654,7 +673,8 @@ func TestLDAPHandshakeMalformedResponse(t *testing.T) {
 		t.Fatalf("expected parse failure prefix, got: %v", err)
 	}
 
-	if err := <-serverErr; err != nil {
+	err = <-serverErr
+	if err != nil {
 		t.Fatalf("server error: %v", err)
 	}
 }
@@ -790,6 +810,7 @@ func TestMySQLReadPacketErrorCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rw := bufio.NewReadWriter(bufio.NewReader(bytes.NewReader(tt.packet)), bufio.NewWriter(io.Discard))
+
 			_, err := p.readMySQLPacket(rw)
 			if err == nil {
 				t.Fatal("expected error, got nil")
@@ -812,8 +833,8 @@ func TestProtocolNames(t *testing.T) {
 		{name: "imap", protocol: newIMAPProtocol(), expected: "imap"},
 		{name: "pop3", protocol: newPOP3Protocol(), expected: "pop3"},
 		{name: "ftp", protocol: newFTPProtocol(), expected: "ftp"},
-		{name: "ldap", protocol: newLDAPProtocol(), expected: "ldap"},
-		{name: "mysql", protocol: newMySQLProtocol(), expected: "mysql"},
+		{name: ldapProtocolName, protocol: newLDAPProtocol(), expected: ldapProtocolName},
+		{name: mysqlProtocolName, protocol: newMySQLProtocol(), expected: mysqlProtocolName},
 	}
 
 	for _, tt := range tests {
@@ -879,6 +900,7 @@ func TestSendStartTLSErrorCases(t *testing.T) {
 
 func TestExpectGreetingReadError(t *testing.T) {
 	rw := bufio.NewReadWriter(bufio.NewReader(bytes.NewReader(nil)), bufio.NewWriter(io.Discard))
+
 	err := expectGreeting(context.Background(), rw, regexp.MustCompile("^220 "))
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -898,6 +920,7 @@ func TestReadBERElementErrorCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := bufio.NewReader(bytes.NewReader(tt.data))
+
 			_, _, err := readBERElement(r)
 			if err == nil {
 				t.Fatal("expected error, got nil")

--- a/starttls/starttls_test.go
+++ b/starttls/starttls_test.go
@@ -29,6 +29,7 @@ var portMap = map[string]string{
 	"25":   "10025", // SMTP
 	"110":  "10110", // POP3
 	"143":  "10143", // IMAP
+	"389":  "10389", // LDAP
 	"3306": "13306", // MySQL
 }
 
@@ -65,8 +66,8 @@ func (s *testServer) start(ctx context.Context) {
 
 		reader := bufio.NewReader(conn)
 
-		// Send greeting
-		if len(s.messages) > 0 {
+		// Send greeting for text-based protocols
+		if len(s.messages) > 0 && s.port != "389" {
 			_, err := conn.Write([]byte(s.messages[0]))
 			if err != nil {
 				s.errors <- fmt.Errorf("failed to write greeting: %w", err)
@@ -75,21 +76,44 @@ func (s *testServer) start(ctx context.Context) {
 		}
 
 		// Read client messages and respond
-		for i := 1; i < len(s.messages); i++ {
-			// For MySQL, just read the SSL request packet and don't respond
-			if s.port == "3306" {
-				buf := make([]byte, 36) // Size of MySQL SSL request packet
+		switch s.port {
+		case "3306":
+			buf := make([]byte, 36) // Size of MySQL SSL request packet
 
-				_, err := io.ReadFull(reader, buf)
-				if err != nil && !errors.Is(err, io.EOF) {
-					s.errors <- fmt.Errorf("failed to read MySQL SSL request: %w", err)
-					return
-				}
+			_, err := io.ReadFull(reader, buf)
+			if err != nil && !errors.Is(err, io.EOF) {
+				s.errors <- fmt.Errorf("failed to read MySQL SSL request: %w", err)
+				return
+			}
 
-				s.received = append(s.received, string(buf))
+			s.received = append(s.received, string(buf))
+		case "389":
+			_, payload, err := readBERElement(reader)
+			if err != nil {
+				s.errors <- fmt.Errorf("failed to read LDAP request: %w", err)
+				return
+			}
 
-				break // MySQL doesn't expect a response after SSL request
-			} else {
+			s.received = append(s.received, fmt.Sprintf("ldap:%x", payload))
+
+			messageID, _, _, err := parseLDAPMessageIDAndProtocolOp(payload)
+			if err != nil {
+				s.errors <- fmt.Errorf("failed to decode LDAP messageID: %w", err)
+				return
+			}
+
+			ldapResult := append(encodeBERTLV(0x0a, []byte{0x00}), encodeBERTLV(0x04, []byte{})...)
+			ldapResult = append(ldapResult, encodeBERTLV(0x04, []byte{})...)
+			extendedResponse := encodeBERTLV(0x78, ldapResult)
+			response := encodeBERTLV(0x30, append(encodeBERTLV(0x02, encodeBERIntegerValue(messageID)), extendedResponse...))
+
+			_, err = conn.Write(response)
+			if err != nil {
+				s.errors <- fmt.Errorf("failed to write LDAP response: %w", err)
+				return
+			}
+		default:
+			for i := 1; i < len(s.messages); i++ {
 				// For text protocols, read until newline
 				msg, err := reader.ReadString('\n')
 				if err != nil && !errors.Is(err, io.EOF) {
@@ -201,6 +225,11 @@ func TestStartTLS(t *testing.T) {
 			expectError:   true,
 			expectedError: ErrStartTLSNotSupported,
 			timeout:       2 * time.Second,
+		},
+		{
+			name:    "ldap success",
+			port:    "389",
+			timeout: 2 * time.Second,
 		},
 		{
 			name: "mysql success",

--- a/starttls/starttls_test.go
+++ b/starttls/starttls_test.go
@@ -2,11 +2,15 @@ package starttls
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net"
+	"regexp"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -407,5 +411,526 @@ func TestTimeout(t *testing.T) {
 	// The error should be a context deadline exceeded error
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("Expected context deadline exceeded error, got: %v", err)
+	}
+}
+
+func TestLDAPHandshakeMessageIDMismatch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	atomic.StoreUint32(&ldapMessageIDCounter, 0)
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	serverErr := make(chan error, 1)
+
+	go func() {
+		defer close(serverErr)
+
+		reader := bufio.NewReader(serverConn)
+		_, payload, err := readBERElement(reader)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+
+		messageID, _, _, err := parseLDAPMessageIDAndProtocolOp(payload)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+
+		// Reply with a different message ID to trigger the mismatch branch.
+		response := buildLDAPExtendedResponse(messageID+1, 0)
+		_, err = serverConn.Write(response)
+		serverErr <- err
+	}()
+
+	err := StartTLS(ctx, clientConn, "389")
+	if err == nil {
+		t.Fatal("expected LDAP messageID mismatch error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "messageID mismatch") {
+		t.Fatalf("expected messageID mismatch error, got: %v", err)
+	}
+
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error: %v", err)
+	}
+}
+
+func TestParseLDAPResponseErrorCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		response    []byte
+		errContains string
+	}{
+		{
+			name:        "invalid top-level tag",
+			response:    encodeBERTLV(0x31, []byte{}),
+			errContains: "expected LDAPMessage SEQUENCE",
+		},
+		{
+			name:        "non-success result code",
+			response:    buildLDAPExtendedResponse(1, 2),
+			errContains: "ldap resultCode=2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := bufio.NewReadWriter(bufio.NewReader(bytes.NewReader(tt.response)), bufio.NewWriter(io.Discard))
+
+			_, err := parseLDAPResponse(rw)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+			}
+		})
+	}
+}
+
+func TestParseBERLengthErrorCases(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "missing length", data: []byte{}},
+		{name: "indefinite length", data: []byte{0x80}},
+		{name: "length too large", data: []byte{0x85, 0x01, 0x02, 0x03, 0x04, 0x05}},
+		{name: "incomplete long-form length", data: []byte{0x82, 0x01}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := parseBERLength(tt.data)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !errors.Is(err, ErrInvalidResponse) {
+				t.Fatalf("expected ErrInvalidResponse, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestReadBERLengthErrorCases(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "missing first byte", data: []byte{}},
+		{name: "indefinite length", data: []byte{0x80}},
+		{name: "length too large", data: []byte{0x85, 0x00, 0x00, 0x00, 0x00, 0x00}},
+		{name: "incomplete length bytes", data: []byte{0x82, 0x01}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := bufio.NewReader(bytes.NewReader(tt.data))
+			_, err := readBERLength(r)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !errors.Is(err, ErrInvalidResponse) {
+				t.Fatalf("expected ErrInvalidResponse, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestDecodeBERIntegerErrorCases(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty", data: []byte{}},
+		{name: "too large", data: []byte{0x00, 0x00, 0x00, 0x00, 0x01}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := decodeBERInteger(tt.data)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+func buildLDAPExtendedResponse(messageID, resultCode int) []byte {
+	ldapResult := append(encodeBERTLV(0x0a, encodeBERIntegerValue(resultCode)), encodeBERTLV(0x04, []byte{})...)
+	ldapResult = append(ldapResult, encodeBERTLV(0x04, []byte{})...)
+	extendedResponse := encodeBERTLV(0x78, ldapResult)
+
+	return encodeBERTLV(0x30, append(encodeBERTLV(0x02, encodeBERIntegerValue(messageID)), extendedResponse...))
+}
+
+type failWriter struct {
+	err error
+}
+
+func (w *failWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
+}
+
+func TestLDAPHandshakeWriteAndFlushErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		writerSize  int
+		errContains string
+	}{
+		{
+			name:        "write error",
+			writerSize:  1,
+			errContains: "failed to write StartTLS request",
+		},
+		{
+			name:        "flush error",
+			writerSize:  4096,
+			errContains: "failed to flush StartTLS request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newLDAPProtocol()
+			rw := bufio.NewReadWriter(
+				bufio.NewReader(bytes.NewReader(nil)),
+				bufio.NewWriterSize(&failWriter{err: errors.New("boom")}, tt.writerSize),
+			)
+
+			err := p.Handshake(context.Background(), rw)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+			}
+		})
+	}
+}
+
+func TestLDAPHandshakeMalformedResponse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	serverErr := make(chan error, 1)
+
+	go func() {
+		defer close(serverErr)
+
+		reader := bufio.NewReader(serverConn)
+		_, _, err := readBERElement(reader)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+
+		// Invalid LDAP message tag to trigger parse failure path in Handshake.
+		_, err = serverConn.Write(encodeBERTLV(0x31, []byte{}))
+		serverErr <- err
+	}()
+
+	err := StartTLS(ctx, clientConn, "389")
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to parse StartTLS response") {
+		t.Fatalf("expected parse failure prefix, got: %v", err)
+	}
+
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error: %v", err)
+	}
+}
+
+func TestParseLDAPMessageIDAndProtocolOpErrorCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     []byte
+		errContains string
+	}{
+		{
+			name: "invalid message id tag",
+			payload: append(
+				encodeBERTLV(0x04, []byte{0x01}),
+				encodeBERTLV(0x78, encodeBERTLV(0x0a, []byte{0x00}))...,
+			),
+			errContains: "expected messageID INTEGER",
+		},
+		{
+			name: "invalid message id value",
+			payload: append(
+				encodeBERTLV(0x02, []byte{}),
+				encodeBERTLV(0x78, encodeBERTLV(0x0a, []byte{0x00}))...,
+			),
+			errContains: "invalid messageID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, err := parseLDAPMessageIDAndProtocolOp(tt.payload)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+			}
+		})
+	}
+}
+
+func TestValidateLDAPResultCodeErrorCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		tag         byte
+		value       []byte
+		errContains string
+	}{
+		{
+			name:        "invalid protocol op tag",
+			tag:         0x77,
+			value:       []byte{},
+			errContains: "expected ExtendedResponse tag 0x78",
+		},
+		{
+			name:        "invalid result code tag",
+			tag:         0x78,
+			value:       encodeBERTLV(0x04, []byte{0x00}),
+			errContains: "expected resultCode ENUMERATED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLDAPResultCode(tt.tag, tt.value)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+			}
+		})
+	}
+}
+
+func TestMySQLParseHandshakePacketErrorCases(t *testing.T) {
+	p := newMySQLProtocol()
+
+	tests := []struct {
+		name        string
+		body        []byte
+		errContains string
+	}{
+		{
+			name:        "unsupported protocol version",
+			body:        []byte{0x09},
+			errContains: "unsupported protocol version",
+		},
+		{
+			name: "packet too short for capability flags",
+			// protocol version + empty server version + threadID + auth part + null + filler
+			body:        []byte{0x0a, 0x00, 0, 0, 0, 0, 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 0x00, 0x00},
+			errContains: "packet too short for capability flags",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := p.parseHandshakePacket(tt.body)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+			}
+		})
+	}
+}
+
+func TestMySQLReadPacketErrorCases(t *testing.T) {
+	p := newMySQLProtocol()
+
+	tests := []struct {
+		name        string
+		packet      []byte
+		errContains string
+	}{
+		{
+			name:        "short header",
+			packet:      []byte{0x01, 0x02},
+			errContains: "failed to read packet header",
+		},
+		{
+			name:        "short body",
+			packet:      []byte{0x04, 0x00, 0x00, 0x00, 0x01},
+			errContains: "failed to read packet body",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := bufio.NewReadWriter(bufio.NewReader(bytes.NewReader(tt.packet)), bufio.NewWriter(io.Discard))
+			_, err := p.readMySQLPacket(rw)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+			}
+		})
+	}
+}
+
+func TestProtocolNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol StartTLSProtocol
+		expected string
+	}{
+		{name: "smtp", protocol: newSMTPProtocol(), expected: "smtp"},
+		{name: "imap", protocol: newIMAPProtocol(), expected: "imap"},
+		{name: "pop3", protocol: newPOP3Protocol(), expected: "pop3"},
+		{name: "ftp", protocol: newFTPProtocol(), expected: "ftp"},
+		{name: "ldap", protocol: newLDAPProtocol(), expected: "ldap"},
+		{name: "mysql", protocol: newMySQLProtocol(), expected: "mysql"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.protocol.Name(); got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestEncodeBERLengthLongFormBranches(t *testing.T) {
+	tests := []struct {
+		name     string
+		length   int
+		expected []byte
+	}{
+		{name: "short form", length: 127, expected: []byte{0x7f}},
+		{name: "long form 1 byte", length: 128, expected: []byte{0x81, 0x80}},
+		{name: "long form 2 bytes", length: 256, expected: []byte{0x82, 0x01, 0x00}},
+		{name: "long form 3 bytes", length: 65536, expected: []byte{0x83, 0x01, 0x00, 0x00}},
+		{name: "long form 4 bytes", length: 16777216, expected: []byte{0x84, 0x01, 0x00, 0x00, 0x00}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := encodeBERLength(tt.length)
+			if !bytes.Equal(got, tt.expected) {
+				t.Fatalf("expected %x, got %x", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestSendStartTLSErrorCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		writerSize  int
+		errContains string
+	}{
+		{name: "write error", writerSize: 1, errContains: "boom"},
+		{name: "flush error", writerSize: 4096, errContains: "boom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := bufio.NewReadWriter(
+				bufio.NewReader(bytes.NewReader(nil)),
+				bufio.NewWriterSize(&failWriter{err: errors.New("boom")}, tt.writerSize),
+			)
+
+			err := sendStartTLS(context.Background(), rw, "STARTTLS\r\n", regexp.MustCompile("^220 "))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+			}
+		})
+	}
+}
+
+func TestExpectGreetingReadError(t *testing.T) {
+	rw := bufio.NewReadWriter(bufio.NewReader(bytes.NewReader(nil)), bufio.NewWriter(io.Discard))
+	err := expectGreeting(context.Background(), rw, regexp.MustCompile("^220 "))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestReadBERElementErrorCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		errContains string
+	}{
+		{name: "missing tag", data: []byte{}, errContains: "failed to read BER tag"},
+		{name: "incomplete value", data: []byte{0x04, 0x03, 0x01}, errContains: "failed to read BER value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := bufio.NewReader(bytes.NewReader(tt.data))
+			_, _, err := readBERElement(r)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+			}
+		})
+	}
+}
+
+func TestParseBERElementErrorCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		errContains string
+	}{
+		{name: "too short", data: []byte{0x04}, errContains: "BER element too short"},
+		{name: "missing length", data: []byte{0x04}, errContains: "BER element too short"},
+		{name: "length exceeds payload", data: []byte{0x04, 0x02, 0x01}, errContains: "BER element length exceeds payload"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, err := parseBERElement(tt.data)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This pull request adds support for the LDAP protocol's StartTLS negotiation (port 389) to the codebase. It implements the LDAP StartTLS handshake using BER encoding/decoding, updates the protocol registry, and adds integration tests to verify the handshake and TLS upgrade. Documentation has also been updated to reflect the new support.

**LDAP StartTLS protocol support:**

* Added a new `ldapProtocol` implementation in `starttls/starttls.go` that performs the LDAP StartTLS handshake, including BER encoding/decoding of request and response, message ID validation, and result code checking.
* Registered the LDAP protocol (port 389) in the protocol registry so it is recognized and handled automatically.

**Testing:**

* Added and enabled an integration test in `integration_tests/ldap_test.go` to verify the LDAP StartTLS handshake and subsequent TLS connection. [[1]](diffhunk://#diff-79a23ecb50e65861e3089cdb6cc51d96b6f226c7766ba0019cc57f1abd63535fL25-L27) [[2]](diffhunk://#diff-79a23ecb50e65861e3089cdb6cc51d96b6f226c7766ba0019cc57f1abd63535fL50-R59)
* Updated the Makefile to use the correct `integration_tests` directory for LDAP tests.

**Documentation:**

* Updated `README.md` to document LDAP (port 389) support and provide details about the handshake and encoding. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R105-R109)