### PR TITLE
More integratation tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,11 +24,20 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
-      - name: Run integration tests
+      - name: Set up environment
         run: |
           set -e
           bash setup.sh 2> /dev/null
-          trap 'docker compose -f docker-compose.yml down' EXIT
+
+      - name: Run integration tests
+        run: |
+          set -e
           docker compose -f docker-compose.yml up --quiet-pull  -d
           sleep 30
           go test -v -tags=integration ./...
+
+      - name: Tear down environment
+        if: always()
+        run: |
+          set -e
+          docker compose -f docker-compose.yml down

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,9 +27,8 @@ jobs:
       - name: Run integration tests
         run: |
           set -e
-          bash setup.sh > /dev/null 2>&1
+          bash setup.sh
           trap 'docker compose -f docker-compose.yml down' EXIT
           docker compose -f docker-compose.yml up --quiet-pull  -d
           sleep 30
-          docker compose logs mysql
           go test -v -tags=integration ./...

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,4 +31,5 @@ jobs:
           trap 'docker compose -f docker-compose.yml down' EXIT
           docker compose -f docker-compose.yml up --quiet-pull  -d
           sleep 30
+          docker compose logs mysql
           go test -v -tags=integration ./...

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run integration tests
         run: |
           set -e
-          bash setup.sh
+          bash setup.sh 2>/dev/null
           trap 'docker compose -f docker-compose.yml down' EXIT
           docker compose -f docker-compose.yml up --quiet-pull  -d
           sleep 30

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run integration tests
         run: |
           set -e
-          bash setup.sh 2>/dev/null
+          bash setup.sh
           trap 'docker compose -f docker-compose.yml down' EXIT
           docker compose -f docker-compose.yml up --quiet-pull  -d
           sleep 30

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run integration tests
         run: |
           set -e
-          bash setup.sh
+          bash setup.sh 2> /dev/null
           trap 'docker compose -f docker-compose.yml down' EXIT
           docker compose -f docker-compose.yml up --quiet-pull  -d
           sleep 30

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,5 +30,5 @@ jobs:
           bash setup.sh > /dev/null 2>&1
           trap 'docker compose -f docker-compose.yml down' EXIT
           docker compose -f docker-compose.yml up --quiet-pull  -d
-          sleep 15
+          sleep 20
           go test -v -tags=integration ./...

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,5 +30,5 @@ jobs:
           bash setup.sh > /dev/null 2>&1
           trap 'docker compose -f docker-compose.yml down' EXIT
           docker compose -f docker-compose.yml up --quiet-pull  -d
-          sleep 20
+          sleep 30
           go test -v -tags=integration ./...

--- a/integration_tests/.gitignore
+++ b/integration_tests/.gitignore
@@ -2,4 +2,4 @@
 *.key
 *.pem
 
-./mailserver/config/*
+mailserver/config/*

--- a/integration_tests/.gitignore
+++ b/integration_tests/.gitignore
@@ -1,3 +1,5 @@
 *.crt
 *.key
 *.pem
+
+./mailserver/config/*

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -1,23 +1,24 @@
 services:
-  # https://github.com/thkukuk/containers-mailserver/blob/master/dovecot/README.md
-  # dovecot:
-  #   image: registry.opensuse.org/opensuse/dovecot
-  #   ports:
-  #     - "110:110"
-  #     - "143:143"
-  #     # - "993:993"
-  #     # - "995:995"
-  #   environment:
-  #     # - DEBUG=1
-  #     - DOVECOT_TLS=1
-  #     - DOVECOT_TLS_CRT=/etc/certs/tls.crt
-  #     - DOVECOT_TLS_KEY=/etc/certs/tls.key
-  #     - DOVECOT_TLS_DH_PARAM=/etc/certs/dhparam.pem
-  #     - ENABLE_IMAP=1
-  #     - ENABLE_POP3=1
-  #   # volumes:
-  #   #   - ./dovecot/certs:/etc/certs:ro
-  #   #   - ./dovecot/conf:/etc/dovecot:rw
+  mailserver:
+    image: mailserver/docker-mailserver:edge
+    hostname: mail.example.com
+    ports:
+      - "110:110"
+      - "143:143"
+    environment:
+      - ENABLE_POP3=1
+      - ENABLE_IMAP=1
+      - ENABLE_SMTPS=1
+      - SSL_TYPE=manual
+      - SSL_CERT_PATH=/tmp/ssl/tls.crt
+      - SSL_KEY_PATH=/tmp/ssl/tls.key
+      - OVERRIDE_HOSTNAME=mail.example.com
+      - PERMIT_DOCKER=host
+    volumes:
+      - ./mailserver/config:/tmp/docker-mailserver
+      - ./mailserver/certs/tls.crt:/tmp/ssl:ro
+    cap_add:
+      - NET_ADMIN
 
   #  https://github.com/thkukuk/containers-mailserver/blob/master/openldap/README.md
   openldap:
@@ -36,21 +37,6 @@ services:
       - LDAP_TLS_CA_CRT=/etc/openldap/certs/tls.crt
     volumes:
       - ./openldap/certs:/etc/openldap/certs
-
-  # https://github.com/thkukuk/containers-mailserver/blob/master/postfix/README.md
-  postfix:
-    image: registry.opensuse.org/opensuse/postfix
-    ports:
-      - "25:25"
-      - "587:587"
-    environment:
-      - SERVER_HOSTNAME=smtp.example.com
-      - ENABLE_SUBMISSION=1
-      - SMTPD_USE_TLS=1
-      - SMTPD_TLS_CRT=/etc/postfix/ssl/certs/tls.crt
-      - SMTPD_TLS_KEY=/etc/postfix/ssl/certs/tls.key
-    volumes:
-      - ./postfix/certs:/etc/postfix/ssl/certs
 
   mysql:
     image: mysql:8.0

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mailserver:
-    image: mailserver/docker-mailserver:edge
+    image: mailserver/docker-mailserver:15.1.0
     hostname: mail.example.com
     ports:
       - "25:25"
@@ -57,7 +57,7 @@ services:
       - ./mysql/certs:/etc/mysql/certs:ro
 
   ftp:
-    image: stilliard/pure-ftpd:latest
+    image: stilliard/pure-ftpd:bookworm-1.0.50
     ports:
       - "21:21"
     environment:

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -3,8 +3,10 @@ services:
     image: mailserver/docker-mailserver:edge
     hostname: mail.example.com
     ports:
+      - "25:25"
       - "110:110"
       - "143:143"
+      - "587:587"
     environment:
       - ENABLE_POP3=1
       - ENABLE_IMAP=1
@@ -14,9 +16,10 @@ services:
       - SSL_KEY_PATH=/tmp/ssl/tls.key
       - OVERRIDE_HOSTNAME=mail.example.com
       - PERMIT_DOCKER=host
+      - ENABLE_UPDATE_CHECK=0
     volumes:
       - ./mailserver/config:/tmp/docker-mailserver
-      - ./mailserver/certs/tls.crt:/tmp/ssl:ro
+      - ./mailserver/certs:/tmp/ssl:ro
     cap_add:
       - NET_ADMIN
 

--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -51,3 +51,31 @@ services:
       - SMTPD_TLS_KEY=/etc/postfix/ssl/certs/tls.key
     volumes:
       - ./postfix/certs:/etc/postfix/ssl/certs
+
+  mysql:
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=rootpass
+      - MYSQL_DATABASE=testdb
+    command:
+      - --ssl-ca=/etc/mysql/certs/ca.pem
+      - --ssl-cert=/etc/mysql/certs/server-cert.pem
+      - --ssl-key=/etc/mysql/certs/server-key.pem
+      - --tls-version=TLSv1.2
+    volumes:
+      - ./mysql/certs:/etc/mysql/certs:ro
+
+  ftp:
+    image: stilliard/pure-ftpd:latest
+    ports:
+      - "21:21"
+    environment:
+      - PUBLICHOST=localhost
+      - FTP_USER_NAME=admin
+      - FTP_USER_PASS=admin
+      - FTP_USER_HOME=/home/admin
+      - ADDED_FLAGS=--tls=2
+    volumes:
+      - ./ftp/certs:/etc/ssl/private:ro

--- a/integration_tests/ftp_test.go
+++ b/integration_tests/ftp_test.go
@@ -1,0 +1,57 @@
+//go:build integration
+
+package integrationtests
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jsandas/starttls-go/starttls"
+)
+
+func TestFTPStartTLS(t *testing.T) {
+	host := os.Getenv("FTP_HOST")
+	port := os.Getenv("FTP_PORT")
+
+	if host == "" {
+		host = "localhost"
+	}
+	if port == "" {
+		port = "21"
+	}
+
+	addr := host + ":" + port
+
+	t.Logf("Attempting to connect to %s", addr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to connect to %s: %v", addr, err)
+	}
+	defer conn.Close()
+
+	err = starttls.StartTLS(ctx, conn, port)
+	if err != nil {
+		t.Fatalf("StartTLS handshake failed: %v", err)
+	}
+
+	tlsConfig := &tls.Config{
+		ServerName:         "localhost",
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+	}
+
+	tlsConn := tls.Client(conn, tlsConfig)
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("TLS handshake failed: %v", err)
+	}
+
+	t.Log("Successfully completed FTP StartTLS handshake")
+}

--- a/integration_tests/imap_test.go
+++ b/integration_tests/imap_test.go
@@ -2,59 +2,56 @@
 
 package integrationtests
 
-// import (
-// 	"context"
-// 	"crypto/tls"
-// 	"net"
-// 	"os"
-// 	"testing"
-// 	"time"
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"os"
+	"testing"
+	"time"
 
-// 	"github.com/jsandas/starttls-go/starttls"
-// )
+	"github.com/jsandas/starttls-go/starttls"
+)
 
-// func TestIMAPStartTLS(t *testing.T) {
-// 	host := os.Getenv("IMAP_HOST")
-// 	port := os.Getenv("IMAP_PORT")
+func TestIMAPStartTLS(t *testing.T) {
+	host := os.Getenv("IMAP_HOST")
+	port := os.Getenv("IMAP_PORT")
 
-// 	if host == "" {
-// 		host = "localhost"
-// 	}
-// 	if port == "" {
-// 		port = "143"
-// 	}
+	if host == "" {
+		host = "localhost"
+	}
+	if port == "" {
+		port = "143"
+	}
 
-// 	addr := host + ":" + port
+	addr := host + ":" + port
 
-// 	t.Logf("Attempting to connect to %s", addr)
+	t.Logf("Attempting to connect to %s", addr)
 
-// 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-// 	defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
-// 	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
-// 	if err != nil {
-// 		t.Fatalf("Failed to connect to %s: %v", addr, err)
-// 	}
-// 	defer conn.Close()
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to connect to %s: %v", addr, err)
+	}
+	defer conn.Close()
 
-// 	// Execute the StartTLS handshake using the package
-// 	err = starttls.StartTLS(ctx, conn, port)
-// 	if err != nil {
-// 		t.Fatalf("StartTLS handshake failed: %v", err)
-// 	}
+	err = starttls.StartTLS(ctx, conn, port)
+	if err != nil {
+		t.Fatalf("StartTLS handshake failed: %v", err)
+	}
 
-// 	// Configure TLS
-// 	tlsConfig := &tls.Config{
-// 		ServerName:         "dovecot.example.com",
-// 		MinVersion:         tls.VersionTLS12,
-// 		InsecureSkipVerify: true, // Set to true for testing purposes; in production, set to false and provide proper certificates
-// 	}
+	tlsConfig := &tls.Config{
+		ServerName:         "mail.example.com",
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+	}
 
-// 	// Upgrade connection to TLS
-// 	tlsConn := tls.Client(conn, tlsConfig)
-// 	if err := tlsConn.Handshake(); err != nil {
-// 		t.Fatalf("TLS handshake failed: %v", err)
-// 	}
+	tlsConn := tls.Client(conn, tlsConfig)
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("TLS handshake failed: %v", err)
+	}
 
-// 	t.Log("Successfully completed IMAP StartTLS handshake")
-// }
+	t.Log("Successfully completed IMAP StartTLS handshake")
+}

--- a/integration_tests/mysql_test.go
+++ b/integration_tests/mysql_test.go
@@ -1,0 +1,58 @@
+package integrationtests
+//go:build integration
+
+package integrationtests
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jsandas/starttls-go/starttls"
+)
+
+func TestMySQLStartTLS(t *testing.T) {
+	host := os.Getenv("MYSQL_HOST")
+	port := os.Getenv("MYSQL_PORT")
+
+	if host == "" {
+		host = "localhost"
+	}
+	if port == "" {
+		port = "3306"
+	}
+
+	addr := host + ":" + port
+
+	t.Logf("Attempting to connect to %s", addr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to connect to %s: %v", addr, err)
+	}
+	defer conn.Close()
+
+	err = starttls.StartTLS(ctx, conn, port)
+	if err != nil {
+		t.Fatalf("StartTLS handshake failed: %v", err)
+	}
+
+	tlsConfig := &tls.Config{
+		ServerName:         "localhost",
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+	}
+
+	tlsConn := tls.Client(conn, tlsConfig)
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("TLS handshake failed: %v", err)
+	}
+
+	t.Log("Successfully completed MySQL StartTLS handshake")
+}

--- a/integration_tests/mysql_test.go
+++ b/integration_tests/mysql_test.go
@@ -1,4 +1,3 @@
-package integrationtests
 //go:build integration
 
 package integrationtests

--- a/integration_tests/pop3_test.go
+++ b/integration_tests/pop3_test.go
@@ -2,59 +2,56 @@
 
 package integrationtests
 
-// import (
-// 	"context"
-// 	"crypto/tls"
-// 	"net"
-// 	"os"
-// 	"testing"
-// 	"time"
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"os"
+	"testing"
+	"time"
 
-// 	"github.com/jsandas/starttls-go/starttls"
-// )
+	"github.com/jsandas/starttls-go/starttls"
+)
 
-// func TestPOP3StartTLS(t *testing.T) {
-// 	host := os.Getenv("POP3_HOST")
-// 	port := os.Getenv("POP3_PORT")
+func TestPOP3StartTLS(t *testing.T) {
+	host := os.Getenv("POP3_HOST")
+	port := os.Getenv("POP3_PORT")
 
-// 	if host == "" {
-// 		host = "localhost"
-// 	}
-// 	if port == "" {
-// 		port = "110"
-// 	}
+	if host == "" {
+		host = "localhost"
+	}
+	if port == "" {
+		port = "110"
+	}
 
-// 	addr := host + ":" + port
+	addr := host + ":" + port
 
-// 	t.Logf("Attempting to connect to %s", addr)
+	t.Logf("Attempting to connect to %s", addr)
 
-// 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-// 	defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
-// 	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
-// 	if err != nil {
-// 		t.Fatalf("Failed to connect to %s: %v", addr, err)
-// 	}
-// 	defer conn.Close()
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to connect to %s: %v", addr, err)
+	}
+	defer conn.Close()
 
-// 	// Execute the StartTLS handshake using the package
-// 	err = starttls.StartTLS(ctx, conn, port)
-// 	if err != nil {
-// 		t.Fatalf("StartTLS handshake failed: %v", err)
-// 	}
+	err = starttls.StartTLS(ctx, conn, port)
+	if err != nil {
+		t.Fatalf("StartTLS handshake failed: %v", err)
+	}
 
-// 	// Configure TLS
-// 	tlsConfig := &tls.Config{
-// 		ServerName:         "dovecot.example.com",
-// 		MinVersion:         tls.VersionTLS12,
-// 		InsecureSkipVerify: true, // Set to true for testing purposes; in production, set to false and provide proper certificates
-// 	}
+	tlsConfig := &tls.Config{
+		ServerName:         "mail.example.com",
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+	}
 
-// 	// Upgrade connection to TLS
-// 	tlsConn := tls.Client(conn, tlsConfig)
-// 	if err := tlsConn.Handshake(); err != nil {
-// 		t.Fatalf("TLS handshake failed: %v", err)
-// 	}
+	tlsConn := tls.Client(conn, tlsConfig)
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("TLS handshake failed: %v", err)
+	}
 
-// 	t.Log("Successfully completed POP3 StartTLS handshake")
-// }
+	t.Log("Successfully completed POP3 StartTLS handshake")
+}

--- a/integration_tests/setup.sh
+++ b/integration_tests/setup.sh
@@ -13,6 +13,8 @@ fi
 mkdir -p dovecot/certs
 mkdir -p openldap/certs
 mkdir -p postfix/certs
+mkdir -p mysql/certs
+mkdir -p ftp/certs
 
 # Generate certificates if they don't exist (or just overwrite for simplicity in test environment)
 echo "Generating certificates..."
@@ -34,6 +36,20 @@ openssl req -x509 -newkey rsa:2048 \
     -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=smtp.example.com" \
     -keyout postfix/certs/tls.key \
     -out postfix/certs/tls.crt
+
+openssl req -x509 -newkey rsa:2048 \
+    -days 3650 -nodes \
+    -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost" \
+    -keyout mysql/certs/server-key.pem \
+    -out mysql/certs/server-cert.pem
+
+cp mysql/certs/server-cert.pem mysql/certs/ca.pem
+
+openssl req -x509 -newkey rsa:2048 \
+    -days 3650 -nodes \
+    -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost" \
+    -keyout ftp/certs/pure-ftpd.pem \
+    -out ftp/certs/pure-ftpd.pem
 
 # Download DH parameters if they don't exist (or just overwrite for simplicity in test environment)
 echo "Setting up DH parameters for Dovecot and OpenLDAP..."

--- a/integration_tests/setup.sh
+++ b/integration_tests/setup.sh
@@ -5,25 +5,19 @@ echo "Running setup script..."
 
 CURRENT_DIR=$(pwd)
 if [ $(basename "$CURRENT_DIR") != "integration_tests" ]; then
-    echo "Please run this script from the integrationtests directory."
+    echo "Please run this script from the integration_tests directory."
     exit 1
 fi
 
 # Ensure directory exists
-mkdir -p dovecot/certs
 mkdir -p openldap/certs
-mkdir -p postfix/certs
+mkdir -p mailserver/certs
+mkdir -p mailserver/config
 mkdir -p mysql/certs
 mkdir -p ftp/certs
 
 # Generate certificates if they don't exist (or just overwrite for simplicity in test environment)
 echo "Generating certificates..."
-
-openssl req -x509 -newkey rsa:2048 \
-    -days 3650 -nodes \
-    -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=dovecot.example.com" \
-    -keyout dovecot/certs/tls.key \
-    -out dovecot/certs/tls.crt
 
 openssl req -x509 -newkey rsa:2048 \
     -days 3650 -nodes \
@@ -33,9 +27,19 @@ openssl req -x509 -newkey rsa:2048 \
 
 openssl req -x509 -newkey rsa:2048 \
     -days 3650 -nodes \
-    -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=smtp.example.com" \
-    -keyout postfix/certs/tls.key \
-    -out postfix/certs/tls.crt
+    -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=mail.example.com" \
+    -keyout mailserver/certs/tls.key \
+    -out mailserver/certs/tls.crt
+
+cat > mailserver/config/hostname.txt <<'EOF'
+mail.example.com
+EOF
+cat > mailserver/config/postfix-accounts.cf <<'EOF'
+user@mail.example.com|{SHA512-CRYPT}$6$rounds=5000$abc$def
+EOF
+
+cat > mailserver/config/relay-hosts.conf <<'EOF'
+EOF
 
 openssl req -x509 -newkey rsa:2048 \
     -days 3650 -nodes \
@@ -57,12 +61,12 @@ if [ ! -f "dhparam.pem" ]; then
     echo "DH parameters do not exist. Downloading..."
     curl -fsSL https://ssl-config.mozilla.org/ffdhe2048.txt -o dhparam.pem
 
-    cp dhparam.pem dovecot/certs/dhparam.pem
+    # cp dhparam.pem mailserver/certs/dhparam.pem
     cp dhparam.pem openldap/certs/dhparam.pem
 else  
     echo "DH parameters already exist. Overwriting..."
 
-    cp dhparam.pem dovecot/certs/dhparam.pem
+    # cp dhparam.pem mailserver/certs/dhparam.pem
     cp dhparam.pem openldap/certs/dhparam.pem
 fi
 

--- a/integration_tests/setup.sh
+++ b/integration_tests/setup.sh
@@ -49,11 +49,15 @@ openssl req -x509 -newkey rsa:2048 \
 
 cp mysql/certs/server-cert.pem mysql/certs/ca.pem
 
+# Generate FTP cert+key bundle for Pure-FTPd (expects combined PEM)
 openssl req -x509 -newkey rsa:2048 \
     -days 3650 -nodes \
     -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost" \
-    -keyout ftp/certs/pure-ftpd.pem \
-    -out ftp/certs/pure-ftpd.pem
+    -keyout ftp/certs/pure-ftpd.key \
+    -out ftp/certs/pure-ftpd.crt
+
+cat ftp/certs/pure-ftpd.key ftp/certs/pure-ftpd.crt > ftp/certs/pure-ftpd.pem
+rm -f ftp/certs/pure-ftpd.key ftp/certs/pure-ftpd.crt
 
 # Download DH parameters if they don't exist (or just overwrite for simplicity in test environment)
 echo "Setting up DH parameters for Dovecot and OpenLDAP..."

--- a/integration_tests/setup.sh
+++ b/integration_tests/setup.sh
@@ -48,7 +48,10 @@ openssl req -x509 -newkey rsa:2048 \
     -out mysql/certs/server-cert.pem
 
 cp mysql/certs/server-cert.pem mysql/certs/ca.pem
-chown -R 999:999 mysql/certs
+
+if [ "$(uname)" = "Linux" ]; then
+    sudo chown -R 999:999 mysql/certs
+fi
 
 # Generate FTP cert+key bundle for Pure-FTPd (expects combined PEM)
 openssl req -x509 -newkey rsa:2048 \

--- a/integration_tests/setup.sh
+++ b/integration_tests/setup.sh
@@ -50,6 +50,7 @@ openssl req -x509 -newkey rsa:2048 \
 cp mysql/certs/server-cert.pem mysql/certs/ca.pem
 
 if [ "$(uname)" = "Linux" ]; then
+    echo "Changing ownership of MySQL certs to UID 999 and GID 999 for Linux..."
     sudo chown -R 999:999 mysql/certs
 fi
 

--- a/integration_tests/setup.sh
+++ b/integration_tests/setup.sh
@@ -48,6 +48,7 @@ openssl req -x509 -newkey rsa:2048 \
     -out mysql/certs/server-cert.pem
 
 cp mysql/certs/server-cert.pem mysql/certs/ca.pem
+chown -R 999:999 mysql/certs
 
 # Generate FTP cert+key bundle for Pure-FTPd (expects combined PEM)
 openssl req -x509 -newkey rsa:2048 \
@@ -60,17 +61,13 @@ cat ftp/certs/pure-ftpd.key ftp/certs/pure-ftpd.crt > ftp/certs/pure-ftpd.pem
 rm -f ftp/certs/pure-ftpd.key ftp/certs/pure-ftpd.crt
 
 # Download DH parameters if they don't exist (or just overwrite for simplicity in test environment)
-echo "Setting up DH parameters for Dovecot and OpenLDAP..."
+echo "Setting up DH parameters for OpenLDAP..."
 if [ ! -f "dhparam.pem" ]; then
     echo "DH parameters do not exist. Downloading..."
     curl -fsSL https://ssl-config.mozilla.org/ffdhe2048.txt -o dhparam.pem
-
-    # cp dhparam.pem mailserver/certs/dhparam.pem
     cp dhparam.pem openldap/certs/dhparam.pem
 else  
     echo "DH parameters already exist. Overwriting..."
-
-    # cp dhparam.pem mailserver/certs/dhparam.pem
     cp dhparam.pem openldap/certs/dhparam.pem
 fi
 

--- a/integration_tests/smtp_test.go
+++ b/integration_tests/smtp_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/jsandas/starttls-go/starttls"
 )
 
-func TestSMTPStartTLS(t *testing.T) {
+func TestSMTPStartTLS587(t *testing.T) {
 	host := os.Getenv("SMTP_HOST")
 	port := os.Getenv("SMTP_PORT")
 
@@ -21,7 +21,7 @@ func TestSMTPStartTLS(t *testing.T) {
 		host = "localhost"
 	}
 	if port == "" {
-		port = "25"
+		port = "587"
 	}
 
 	addr := host + ":" + port

--- a/integration_tests/smtp_test.go
+++ b/integration_tests/smtp_test.go
@@ -45,7 +45,7 @@ func TestSMTPStartTLS(t *testing.T) {
 
 	// Configure TLS
 	tlsConfig := &tls.Config{
-		ServerName:         "smtp.example.com",
+		ServerName:         "mail.example.com",
 		MinVersion:         tls.VersionTLS12,
 		InsecureSkipVerify: true, // Set to true for testing purposes; in production, set to false and provide proper certificates
 	}


### PR DESCRIPTION
This pull request significantly updates the integration test environment and test coverage for StartTLS support across multiple protocols. The main improvements are the replacement of legacy mail server containers with a modern, full-featured mail server, the addition of new integration tests for FTP and MySQL StartTLS, and various updates to the test setup scripts and configuration to support these changes.

**Key changes include:**

### Integration Environment Overhaul
* Replaced the previously commented-out Dovecot and Postfix containers with a single `mailserver/docker-mailserver` container that supports IMAP, POP3, and SMTP (with StartTLS) in `integration_tests/docker-compose.yml`. Added configuration and certificate mounting to support secure connections.
* Added new service containers for `mysql:8.0` (with TLS support) and `stilliard/pure-ftpd` (FTP with StartTLS/TLS), including certificate generation and mounting.

### Integration Test Coverage
* Added new test files: `ftp_test.go` and `mysql_test.go`, each implementing StartTLS handshake tests for FTP and MySQL, respectively. [[1]](diffhunk://#diff-0c157ffabdbf445a4c1d1b6299bd2fb265cdc9d80b7175354ca8ae70c184b11dR1-R57) [[2]](diffhunk://#diff-8db1d1afd346a3c6d5919e1b4d1fa80f9b2fc4b085abb56a7d1a0398b0c94645R1-R57)
* Un-commented and updated the IMAP and POP3 StartTLS handshake integration tests to use the new mailserver and current test configuration. [[1]](diffhunk://#diff-dd76195d8fa29228ff9a04b83abc52d2082df7f502fb3e50a69f13a395cf5775L5-R57) [[2]](diffhunk://#diff-fca450560f2afc9774a5d434daf47c665751d05b06df5619b07d9cd7ea4af20fL5-R57)
* Updated the SMTP StartTLS test to run on port 587 and use the new mailserver hostname. [[1]](diffhunk://#diff-6adcec085ca19c2270a7c979303f93b39351391813f03b09a55aa50a7a5ac8aaL16-R24) [[2]](diffhunk://#diff-6adcec085ca19c2270a7c979303f93b39351391813f03b09a55aa50a7a5ac8aaL48-R48)

### Test Setup and Configuration
* Updated `setup.sh` to generate and place certificates in the correct directories for the new mailserver, MySQL, and FTP containers, and to create required config files for the mailserver. Removed obsolete Dovecot/Postfix logic. [[1]](diffhunk://#diff-9bb32a96fedc44443e8c0ec6e31f438be74a696b993cac14349202a0d3a6c57bL8-L25) [[2]](diffhunk://#diff-9bb32a96fedc44443e8c0ec6e31f438be74a696b993cac14349202a0d3a6c57bL34-L49)
* Added `mailserver/config/*` to `.gitignore` to prevent test configuration files from being committed.

### CI Workflow Improvements
* Updated `.github/workflows/integration.yml` to set up the environment before integration tests, increase container startup wait time, and ensure proper teardown of the environment after tests.

These changes modernize and expand the integration test suite, ensuring robust StartTLS testing across all supported protocols and improving reliability and maintainability of the test infrastructure.