### PR TITLE
Update README with new badges

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: Code
 
 on:
   push:
@@ -9,23 +9,11 @@ on:
       - main
 
 jobs:
-  lint:
-    permissions:
-      contents: read
-    uses: jsandas/github-actions/.github/workflows/golang-lint.yml@13150b57906d67e1731f602c2b78a5d13b13b1bc
-
-  security:
-    permissions:
-      contents: read
-      security-events: write
-    uses: jsandas/github-actions/.github/workflows/golang-security.yml@13150b57906d67e1731f602c2b78a5d13b13b1bc
-
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [lint]
     
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,9 @@
 name: Integration Tests
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: Integration
 
 on:
   push:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    name: Integration Tests
+    name: Protocol Integration Tests 
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,22 @@
+name: Quality
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    permissions:
+      contents: read
+    name: Lint Checks
+    uses: jsandas/github-actions/.github/workflows/golang-lint.yml@13150b57906d67e1731f602c2b78a5d13b13b1bc
+
+  security:
+    permissions:
+      contents: read
+      security-events: write
+    name: Security Checks
+    uses: jsandas/github-actions/.github/workflows/golang-security.yml@13150b57906d67e1731f602c2b78a5d13b13b1bc

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # starttls-go
 
-[![CI](https://github.com/jsandas/starttls-go/actions/workflows/ci.yml/badge.svg)](https://github.com/jsandas/starttls-go/actions/workflows/ci.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/jsandas/starttls-go)](https://goreportcard.com/report/github.com/jsandas/starttls-go)
+[![Integration Tests](https://github.com/jsandas/starttls-go/actions/workflows/integration.yml/badge.svg)](https://github.com/jsandas/starttls-go/actions/workflows/integration.yml)
+[![Unit Tests](https://github.com/jsandas/starttls-go/actions/workflows/unit.yml/badge.svg)](https://github.com/jsandas/starttls-go/actions/workflows/unit.yml)
 [![GoDoc](https://godoc.org/github.com/jsandas/starttls-go?status.svg)](https://godoc.org/github.com/jsandas/starttls-go)
 
 A Go module that handles STARTTLS negotiation for various protocols. STARTTLS allows upgrading a plain text connection to use TLS encryption after the initial connection is established.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # starttls-go
 
 [![Integration Tests](https://github.com/jsandas/starttls-go/actions/workflows/integration.yml/badge.svg)](https://github.com/jsandas/starttls-go/actions/workflows/integration.yml)
-[![Unit Tests](https://github.com/jsandas/starttls-go/actions/workflows/unit.yml/badge.svg)](https://github.com/jsandas/starttls-go/actions/workflows/unit.yml)
+[![Code Tests](https://github.com/jsandas/starttls-go/actions/workflows/code.yml/badge.svg)](https://github.com/jsandas/starttls-go/actions/workflows/code.yml)
+[![Quality Checks](https://github.com/jsandas/starttls-go/actions/workflows/quality.yml/badge.svg)](https://github.com/jsandas/starttls-go/actions/workflows/quality.yml)
 [![GoDoc](https://godoc.org/github.com/jsandas/starttls-go?status.svg)](https://godoc.org/github.com/jsandas/starttls-go)
 
 A Go module that handles STARTTLS negotiation for various protocols. STARTTLS allows upgrading a plain text connection to use TLS encryption after the initial connection is established.


### PR DESCRIPTION
This pull request restructures the GitHub Actions workflows to improve CI/CD organization and clarity. Lint and security checks are now separated into a dedicated workflow, workflow names and badges are updated for consistency, and integration tests have their own workflow. The most important changes are:

**Workflow restructuring and separation:**

* Created a new `.github/workflows/quality.yml` workflow to handle lint and security checks, moving these jobs out of the main code workflow.
* Renamed `.github/workflows/unit.yml` to `.github/workflows/code.yml`, and removed lint and security jobs from this workflow, leaving only unit tests. [[1]](diffhunk://#diff-2d2301c62da7f04adcadfbd43fa4063e9ad651296b6f190974b99e72a00017a2L1-R1) [[2]](diffhunk://#diff-2d2301c62da7f04adcadfbd43fa4063e9ad651296b6f190974b99e72a00017a2L12-L28)

**Integration workflow improvements:**

* Updated `.github/workflows/integration.yml` to trigger on both `push` and `pull_request` events to the `main` branch, and clarified job naming. [[1]](diffhunk://#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8bL1-R6) [[2]](diffhunk://#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8bL13-R16)

**Documentation updates:**

* Updated `README.md` badges to reflect the new workflow names and structure, linking to integration, code, and quality workflows.  Removed Go Report Card badge as this service is deprecated.