### PR TITLE
Clarify implemented protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Integration Tests](https://github.com/jsandas/starttls-go/actions/workflows/integration.yml/badge.svg)](https://github.com/jsandas/starttls-go/actions/workflows/integration.yml)
 [![Code Tests](https://github.com/jsandas/starttls-go/actions/workflows/code.yml/badge.svg)](https://github.com/jsandas/starttls-go/actions/workflows/code.yml)
 [![Quality Checks](https://github.com/jsandas/starttls-go/actions/workflows/quality.yml/badge.svg)](https://github.com/jsandas/starttls-go/actions/workflows/quality.yml)
+[![CodeCov](https://codecov.io/gh/jsandas/starttls-go/graph/badge.svg?token=S2805SVWX4)](https://codecov.io/gh/jsandas/starttls-go)
 [![GoDoc](https://godoc.org/github.com/jsandas/starttls-go?status.svg)](https://godoc.org/github.com/jsandas/starttls-go)
 
 A Go module that handles STARTTLS (a.k.a. opportunistic TLS) negotiation for various protocols. STARTTLS allows upgrading a plain text connection to use TLS encryption after the initial connection is established. This module performs a no-op for any ports not in the STARTTLS protocol map, making it safe to use even if the destination server uses implicit TLS (e.g., HTTPS, LDAPS, etc.).

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Quality Checks](https://github.com/jsandas/starttls-go/actions/workflows/quality.yml/badge.svg)](https://github.com/jsandas/starttls-go/actions/workflows/quality.yml)
 [![GoDoc](https://godoc.org/github.com/jsandas/starttls-go?status.svg)](https://godoc.org/github.com/jsandas/starttls-go)
 
-A Go module that handles STARTTLS negotiation for various protocols. STARTTLS allows upgrading a plain text connection to use TLS encryption after the initial connection is established.
+A Go module that handles STARTTLS (aka Opportunistic TLS) negotiation for various protocols. STARTTLS allows upgrading a plain text connection to use TLS encryption after the initial connection is established.  Module performs no-op for any ports not in the STARTTLS protocol map making it safe to use even if destination server uses implicit TLS (e.g. HTTPS, LDAPS, etc.)
 
-## Supported Protocols
+## Implemented Protocols
 
 - SMTP (ports 25, 587)
 - IMAP (port 143)
@@ -15,7 +15,6 @@ A Go module that handles STARTTLS negotiation for various protocols. STARTTLS al
 - FTP (port 21)
 - LDAP (port 389)
 - MySQL (port 3306)
-- Direct TLS ports (443, 465, 993, 995, 3389, 8443, 9443)
 
 ## Installation
 
@@ -108,8 +107,6 @@ For more examples, see the [examples](./examples) directory.
 - Uses BER encoding/decoding for request and response
 - Validates response message ID and result code
 
-### Non-STARTTLS (unknown) ports
-- No-op for ports that are not in the STARTTLS protocol map (callers should establish TLS directly when required)
 ## Error Handling
 
 The module provides specific error types:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Quality Checks](https://github.com/jsandas/starttls-go/actions/workflows/quality.yml/badge.svg)](https://github.com/jsandas/starttls-go/actions/workflows/quality.yml)
 [![GoDoc](https://godoc.org/github.com/jsandas/starttls-go?status.svg)](https://godoc.org/github.com/jsandas/starttls-go)
 
-A Go module that handles STARTTLS (aka Opportunistic TLS) negotiation for various protocols. STARTTLS allows upgrading a plain text connection to use TLS encryption after the initial connection is established.  Module performs no-op for any ports not in the STARTTLS protocol map making it safe to use even if destination server uses implicit TLS (e.g. HTTPS, LDAPS, etc.)
+A Go module that handles STARTTLS (a.k.a. opportunistic TLS) negotiation for various protocols. STARTTLS allows upgrading a plain text connection to use TLS encryption after the initial connection is established. This module performs a no-op for any ports not in the STARTTLS protocol map, making it safe to use even if the destination server uses implicit TLS (e.g., HTTPS, LDAPS, etc.).
 
 ## Implemented Protocols
 


### PR DESCRIPTION
This pull request updates the `README.md` to clarify the module's behavior and supported protocols. The main changes improve documentation accuracy and explain how the module safely handles connections to ports that do not support STARTTLS.

**Documentation improvements:**

* Clarified that the module performs a no-op for ports not in the STARTTLS protocol map, making it safe to use with servers that require implicit TLS (such as HTTPS, LDAPS, etc.) (`README.md`)
* Changed the section heading from "Supported Protocols" to "Implemented Protocols" and removed the listing of direct TLS ports, focusing only on protocols where STARTTLS is applicable (`README.md`)
* Removed the "Non-STARTTLS (unknown) ports" section, as its explanation is now included in the main description (`README.md`)