### PR TITLE
Exclude examples folder from code coverage

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -24,7 +24,7 @@ jobs:
           cache: true
 
       - name: Run unit tests
-        run: go test -v ./... -coverprofile=coverage.out -coverpkg=$(go list ./... | grep -v '/examples' | paste -sd ',' -)
+        run: go test -v -coverprofile=coverage.out -coverpkg="$(go list ./... | grep -vE '/examples(/|$)' | paste -sd ',' -)" ./...
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -24,7 +24,7 @@ jobs:
           cache: true
 
       - name: Run unit tests
-        run: go test -v ./... -coverprofile=coverage.out
+        run: go test -v ./... -coverprofile=coverage.out -coverpkg=$(go list ./... | grep -v '/examples' | paste -sd ',' -)
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0


### PR DESCRIPTION
This pull request makes a small improvement to the test coverage reporting in the CI workflow. The change ensures that the coverage report excludes files in the `/examples` directory, resulting in more accurate code coverage metrics.

* The `go test` command in `.github/workflows/code.yml` was updated to set the `-coverpkg` flag, including all packages except those under `/examples` in the coverage report.